### PR TITLE
docs: update paubox.com/paubox.net links to current URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The Paubox Email API allows your application to send secure, HIPAA compliant ema
 *  [License](#license)
 
 ## External Resources
-*  [Documentation](https://docs.paubox.com/)
-*  [Quickstart Guide](https://docs.paubox.com/docs/paubox_email_api/quickstart)
+*  [Documentation](https://docs.paubox.com/email-api)
+*  [Quickstart Guide](https://docs.paubox.com/email-api/quickstart)
 *  [Changelog](https://github.com/Paubox/paubox-python3/blob/master/CHANGELOG.md)
 
 <a name="#installation"></a>
@@ -25,7 +25,7 @@ The Paubox Email API allows your application to send secure, HIPAA compliant ema
 ### Getting Paubox API Credentials
 You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/pricing/paubox-email-api).
 
-Once you have an account, follow the instructions on the REST API dashboard to verify domain ownership and generate API keys. Further **[quickstart instructions for this process can be found here.](https://docs.paubox.com/paubox_email_api/docs/quickstart)**
+Once you have an account, follow the instructions on the REST API dashboard to verify domain ownership and generate API keys. Further **[quickstart instructions for this process can be found here.](https://docs.paubox.com/email-api/quickstart)**
 
 ### Configuring API Credentials Locally
 


### PR DESCRIPTION
## Summary

The Paubox docs site moved from a Swagger-style structure (`docs.paubox.com/docs/paubox_email_api/...`) to Mintlify (`docs.paubox.com/email-api/...`). Three links in `README.md` still pointed at the legacy paths — two of them returned **404** to anyone clicking through from GitHub. This PR rewrites them to the current canonical URLs per the URL-cleanup brief. README copy only; no code, dependency, version, or behavior changes.

## Inventory and classification

Audited both branches per the brief's workflow.

### `master` (this branch) — 8 raw matches, 3 edits

| Line | Current URL | Liveness | Classification | Action |
|------|-------------|----------|----------------|--------|
| 9 | `https://www.paubox.com` | 200 | Canonical homepage | No change |
| 18 | `https://docs.paubox.com/` | 200 → `/welcome` | Stale root | **Rewrite → `/email-api`** |
| 19 | `https://docs.paubox.com/docs/paubox_email_api/quickstart` | **404** | Pattern A | **Rewrite → `/email-api/quickstart`** |
| 26 | `https://www.paubox.com/pricing/paubox-email-api` | 200 | Canonical marketing target | No change |
| 28 | `https://docs.paubox.com/paubox_email_api/docs/quickstart` | **404** | Pattern B (typo: segments swapped) | **Rewrite → `/email-api/quickstart`** |
| 35 | `https://api.paubox.net/v1/YOUR_ENDPOINT_NAME` | n/a (placeholder) | Well-formed API endpoint | No change |
| 345 | `https://www.paubox.com` | 200 | Canonical homepage | No change |
| `setup.py:10` | `info@paubox.com` | n/a | Email address, not a URL | No change |

**Counts:** canonical/no-change = 5, Pattern A = 1, Pattern B = 1, stale root = 1, flagged = 0.

For line 18 (`docs.paubox.com/` root), the bare URL 301-redirects to `/welcome`. `/email-api` was chosen as the rewrite target instead because it's the more relevant landing page for someone opening a Python SDK README. Confirmed by the maintainer before edits.

### `sdk-generation/v2.0.0` — 25 raw matches, 0 edits

All 25 matches on the v2 branch are `api.paubox.net/v1/YOUR_API_USERNAME` (or `{api_username}` template) placeholders embedded in OpenAPI-generated `paubox/configuration.py`, `paubox/api/*.py`, and `docs/*.md`. These are well-formed API endpoint examples that the brief explicitly excludes (`api.paubox.net` references — generally do not touch). **No `docs.paubox.com` or `www.paubox.com` references exist on v2**, so no separate PR is needed for that branch. Human reviewer please sanity-check this conclusion.

## Edits (before / after)

**README.md:18** — `Documentation` link target
```diff
-*  [Documentation](https://docs.paubox.com/)
+*  [Documentation](https://docs.paubox.com/email-api)
```

**README.md:19** — Pattern A (legacy Swagger path)
```diff
-*  [Quickstart Guide](https://docs.paubox.com/docs/paubox_email_api/quickstart)
+*  [Quickstart Guide](https://docs.paubox.com/email-api/quickstart)
```

**README.md:28** — Pattern B (typo: `paubox_email_api` and `docs` swapped)
```diff
-Once you have an account, follow the instructions on the REST API dashboard to verify domain ownership and generate API keys. Further **[quickstart instructions for this process can be found here.](https://docs.paubox.com/paubox_email_api/docs/quickstart)**
+Once you have an account, follow the instructions on the REST API dashboard to verify domain ownership and generate API keys. Further **[quickstart instructions for this process can be found here.](https://docs.paubox.com/email-api/quickstart)**
```

## Liveness check (pre-edit)

Run with `curl -sIL -o /dev/null --max-time 10 -w '%{http_code} %{url_effective}\n' <URL>`.

| URL | Final status | Final URL |
|-----|--------------|-----------|
| `https://docs.paubox.com/email-api/quickstart` (target) | 200 | identical |
| `https://docs.paubox.com/email-api` (target) | 200 | identical |
| `https://docs.paubox.com/welcome` | 200 | identical |
| `https://docs.paubox.com/` (legacy line 18) | 200 | redirects to `/welcome` |
| `https://docs.paubox.com/docs/paubox_email_api/quickstart` (legacy line 19) | **404** | — |
| `https://docs.paubox.com/paubox_email_api/docs/quickstart` (legacy line 28 typo) | **404** | — |
| `https://www.paubox.com` | 200 | adds trailing `/` only |
| `https://www.paubox.com/pricing/paubox-email-api` | 200 | identical |

All three rewrite targets resolve 200 with no redirects.

## Flagged items

None. Every match on both branches cleanly classified against the brief's rules.

## Test plan

- [ ] Render the PR's README on github.com and click each rewritten link — confirm all three land on a live Mintlify page (no 404, no unexpected redirect).
- [ ] `grep -nE "paubox\.com|paubox\.net" README.md` returns 7 lines, all canonical (9, 18, 19, 26, 28, 35, 345).
- [ ] `git diff master..docs/url-cleanup -- README.md` shows exactly 3 line changes.
- [ ] Confirm no other files were touched: `git diff --stat master..docs/url-cleanup` shows only `README.md | 6 +++---`.
- [ ] (Optional) Re-run `curl -sIL` on `https://docs.paubox.com/email-api` and `https://docs.paubox.com/email-api/quickstart` to confirm they still resolve 200.

Do **not** merge — leaving open for human review per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)