### PR TITLE
Add Paubox Forms API support (v1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# v1.1.0 / 2026-05-21
+### 🚀 New Features
+- Add `PauboxFormsClient` with support for the Paubox Forms API (public endpoints, no API key required)
+  - `get_form(form_id)` — retrieve form metadata, HTML, JSON schema, and CSS by UUID
+  - `submit_form(form_id, form_data, attachments=None)` — submit form data with optional file attachments (up to 250 MB)
+- Export `PauboxFormsClient` from the top-level `paubox` package
+- Add unit tests for `PauboxFormsClient` (no live credentials required)
+- Add `CLAUDE.md` project guide and `api.md` full API reference
+
 # v1.0.0 / 2021-05-12
 ### 🚀 Major Release
 This is the first release of the official Paubox-python3 package. This package is not intended to be backwards compatible with Python2, and users who are using Python2 should navigate to our Python2 [paubox-python](https://github.com/Paubox/paubox-python) package.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md — Paubox Python3 SDK
+
+## Project Overview
+
+Python3 SDK for Paubox APIs. Provides two independent clients:
+
+- **`PauboxApiClient`** — HIPAA-compliant transactional email (requires API key)
+- **`PauboxFormsClient`** — public form retrieval and submission (no auth required)
+
+## Directory Structure
+
+```
+paubox/
+  __init__.py       Public package exports: PauboxApiClient, PauboxFormsClient, Response
+  paubox.py         PauboxApiClient + Response class
+  forms.py          PauboxFormsClient (imports Response from paubox.py)
+  helpers/
+    __init__.py
+    mail.py         Mail helper — formats email message dicts for the Email API
+    errors.py       handle_error(error) — prints error response text and re-raises HTTPError
+
+tests/
+  test_paubox.py    Integration tests for the Email API (requires tests/config.cfg)
+  test_forms.py     Unit tests for the Forms API (no credentials required)
+
+setup.py            Package metadata and dependencies
+README.md           User-facing documentation with code examples
+api.md              Full API reference for both clients
+CHANGELOG.md        Release history
+```
+
+## Running Tests
+
+### Forms API unit tests (no credentials needed)
+
+```bash
+PYTHONPATH=. python tests/test_forms.py
+```
+
+### Email API integration tests
+
+Requires `tests/config.cfg`:
+
+```
+PAUBOX_HOST: 'https://api.paubox.net/v1/YOUR_ENDPOINT_NAME'
+PAUBOX_API_KEY: 'YOUR_API_KEY'
+APPROVED_SENDER: 'sender@yourdomain.com'
+```
+
+```bash
+PYTHONPATH=. python tests/test_paubox.py
+```
+
+## Key Design Decisions
+
+- **`Response` class lives in `paubox/paubox.py`** and is imported by `forms.py` to avoid a breaking change. If you move it, update all importers.
+- **`PauboxFormsClient` accepts an optional `base_url`** constructor argument for test injection (no real HTTP calls in unit tests).
+- **Forms endpoints use `https://next.paubox.com`**; Email endpoints use a per-customer host set via `PAUBOX_HOST`.
+- **No auth headers are sent for Forms API calls** — these are public endpoints called by form respondents.
+- **`submit_form` validates `form_data` locally** before making the network call, raising `ValueError` if it is falsy (mirrors the API's 400 response).
+
+## Environment Variables
+
+| Variable | Used by | Description |
+|---|---|---|
+| `PAUBOX_API_KEY` | `PauboxApiClient` | Paubox Email API key |
+| `PAUBOX_HOST` | `PauboxApiClient` | Email API base URL (e.g. `https://api.paubox.net/v1/your-endpoint`) |
+
+`PauboxFormsClient` has no required environment variables; its base URL defaults to `https://next.paubox.com`.
+
+## Adding a New API Surface
+
+1. Create `paubox/<newapi>.py` with a new client class.
+2. Import `Response` from `.paubox` (or from a future shared response module).
+3. Use `handle_error` from `.helpers.errors` for consistent error handling.
+4. Export the new class from `paubox/__init__.py`.
+5. Add unit tests in `tests/test_<newapi>.py` using `unittest.mock.patch` — no live credentials.
+6. Bump the minor version in `setup.py`, add an entry to `CHANGELOG.md`, and update `README.md` and `api.md`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The Paubox Email API allows your application to send secure, HIPAA compliant ema
 # Table of Contents
 *  [Installation](#installation)
 *  [Usage](#usage)
+   *  [Sending Email](#sending-messages-with-the-paubox-mail-helper)
+   *  [Checking Email Dispositions](#checking-email-dispositions)
+   *  [Paubox Forms API](#paubox-forms-api)
 *  [Contributing](#contributing)
 *  [License](#license)
 
@@ -340,6 +343,58 @@ print(disposition_response.status_code)
 print(disposition_response.headers)
 print(disposition_response.text)
 ```
+<a name="#paubox-forms-api"></a>
+## Paubox Forms API
+
+The Paubox Forms API lets you retrieve form definitions and submit responses. These endpoints are **public** — no API key is required.
+
+### Getting a Form
+
+Retrieve a form's metadata, HTML, JSON schema, and CSS by its UUID.
+
+```python
+import paubox
+
+forms_client = paubox.PauboxFormsClient()
+response = forms_client.get_form("your-form-uuid-here")
+print(response.status_code)   # 200
+print(response.to_dict)       # dict with id, title, form_html, form_json, form_css, etc.
+```
+
+### Submitting a Form
+
+```python
+import paubox
+
+forms_client = paubox.PauboxFormsClient()
+response = forms_client.submit_form(
+    "your-form-uuid-here",
+    form_data={"first_name": "Jane", "last_name": "Doe", "email": "jane@example.com"}
+)
+print(response.status_code)   # 201
+```
+
+### Submitting a Form with File Attachments
+
+Attachments must be base64-encoded. Maximum total request size is 250 MB.
+
+```python
+import paubox
+import base64
+
+forms_client = paubox.PauboxFormsClient()
+
+with open("consent.pdf", "rb") as f:
+    encoded = base64.b64encode(f.read()).decode("utf-8")
+
+response = forms_client.submit_form(
+    "your-form-uuid-here",
+    form_data={"first_name": "Jane", "signature": "{signature_field}"},
+    attachments=[{"name": "consent.pdf", "content": encoded}]
+)
+print(response.status_code)   # 201
+```
+
 <a name="#contributing"></a>
 ## Contributing
 The Paubox-python3 SDK is maintained by [Paubox, Inc.](https://www.paubox.com)

--- a/api.md
+++ b/api.md
@@ -1,0 +1,278 @@
+# Paubox Python3 SDK — API Reference
+
+## Overview
+
+The SDK exposes two independent clients and a shared `Response` class:
+
+| Class | Module | Auth required | Base URL |
+|---|---|---|---|
+| `PauboxApiClient` | `paubox.paubox` | Yes — `Token token=<key>` | Per-customer (`PAUBOX_HOST`) |
+| `PauboxFormsClient` | `paubox.forms` | No | `https://next.paubox.com` |
+| `Response` | `paubox.paubox` | — | — |
+
+All three are importable directly from the top-level package:
+
+```python
+import paubox
+paubox.PauboxApiClient(...)
+paubox.PauboxFormsClient(...)
+# paubox.Response is returned by client methods, not instantiated directly
+```
+
+---
+
+## `Response`
+
+Wraps a `requests.Response` object returned by all client methods.
+
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `status_code` | `int` | HTTP status code |
+| `headers` | `dict` | Response headers |
+| `text` | `str` | Raw response body |
+| `to_dict` | `dict` or `None` | Response body parsed as JSON; `None` if body is empty |
+
+---
+
+## Email API — `PauboxApiClient`
+
+### Constructor
+
+```python
+PauboxApiClient(api_key=None, host=None)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | `str` | `os.environ.get('PAUBOX_API_KEY')` | Paubox Email API key |
+| `host` | `str` | `os.environ.get('PAUBOX_HOST')` | Email API base URL |
+
+### `send(mail)`
+
+Send a message through the Paubox Email API.
+
+```
+POST {host}/messages
+Authorization: Token token={api_key}
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `mail` | `dict` | Formatted message dict. Use `Mail.get()` or build manually (see README). |
+
+**Returns** `Response` — `status_code` 200 on success. `response.to_dict['sourceTrackingId']` contains the tracking ID.
+
+**Raises** `requests.exceptions.HTTPError` on failure.
+
+**Example**
+
+```python
+from paubox.helpers.mail import Mail
+import paubox
+
+client = paubox.PauboxApiClient("YOUR_API_KEY", "https://api.paubox.net/v1/YOUR_ENDPOINT")
+mail = Mail("sender@yourdomain.com", "Hello!", ["recipient@example.com"], {"text/plain": "Hi"})
+response = client.send(mail.get())
+tracking_id = response.to_dict["sourceTrackingId"]
+```
+
+### `get(tracking_code)`
+
+Retrieve the delivery disposition of a sent message.
+
+```
+GET {host}/message_receipt?sourceTrackingId={tracking_code}
+Authorization: Token token={api_key}
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `tracking_code` | `str` | `sourceTrackingId` returned from `send()` |
+
+**Returns** `Response` — disposition data in `response.to_dict`.
+
+**Raises** `requests.exceptions.HTTPError` on failure.
+
+---
+
+## Forms API — `PauboxFormsClient`
+
+These are **public endpoints** — no API key is required. They are intended to be called by form respondents (or on their behalf).
+
+### Constructor
+
+```python
+PauboxFormsClient(base_url="https://next.paubox.com")
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `base_url` | `str` | `"https://next.paubox.com"` | Forms API base URL. Override for testing. |
+
+### `get_form(form_id)`
+
+Retrieve a form's full definition (metadata, HTML, JSON schema, CSS).
+
+```
+GET {base_url}/public/form_data/{form_id}
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `form_id` | `str` | UUID of the form to retrieve |
+
+**Returns** `Response` — `status_code` 200. `response.to_dict` contains the form object:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `str` (UUID) | Form UUID |
+| `title` | `str` | Form title |
+| `description` | `str` or `null` | Optional description |
+| `form_html` | `str` or `null` | Rendered HTML for embedding |
+| `form_json` | `object` or `null` | JSON schema of form fields |
+| `form_css` | `str` or `null` | CSS for the form |
+| `active` | `bool` | Whether the form accepts submissions |
+| `signable` | `bool` | Whether the form supports signatures |
+| `submission_count` | `int` | Total submissions received |
+| `customer_id` | `int` | Owning customer ID |
+| `created_at` | `str` (ISO 8601) | Creation timestamp |
+| `updated_at` | `str` (ISO 8601) | Last updated timestamp |
+
+**Raises** `requests.exceptions.HTTPError` on 404 (form not found) or other HTTP errors.
+
+**Example**
+
+```python
+import paubox
+
+client = paubox.PauboxFormsClient()
+response = client.get_form("550e8400-e29b-41d4-a716-446655440000")
+form = response.to_dict
+print(form["title"])     # "Patient Intake Form"
+print(form["active"])    # True
+```
+
+### `submit_form(form_id, form_data, attachments=None)`
+
+Submit a respondent's answers for a form. Maximum request size is **250 MB**.
+
+```
+POST {base_url}/api/forms/{form_id}/submissions
+```
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `form_id` | `str` | Yes | UUID of the form being submitted |
+| `form_data` | `dict` | Yes | Key-value pairs matching the form's field schema (`form_json`). Structure varies per form. |
+| `attachments` | `list` or `None` | No | List of attachment dicts. Each must have `name` (filename) and `content` (base64-encoded bytes). |
+
+**Returns** `Response` — `status_code` 201, empty body (`response.to_dict` is `None`).
+
+**Raises**
+- `ValueError` — if `form_data` is `None` or empty.
+- `requests.exceptions.HTTPError` — on 400 (missing `form_data`) or 404 (form not found).
+
+**Examples**
+
+Text fields only:
+
+```python
+import paubox
+
+client = paubox.PauboxFormsClient()
+response = client.submit_form(
+    "550e8400-e29b-41d4-a716-446655440000",
+    form_data={"first_name": "Jane", "last_name": "Doe", "email": "jane@example.com"}
+)
+print(response.status_code)  # 201
+```
+
+With file attachments:
+
+```python
+import paubox
+import base64
+
+client = paubox.PauboxFormsClient()
+
+with open("consent.pdf", "rb") as f:
+    encoded = base64.b64encode(f.read()).decode("utf-8")
+
+response = client.submit_form(
+    "550e8400-e29b-41d4-a716-446655440000",
+    form_data={"first_name": "Jane", "signature": "{signature_field}"},
+    attachments=[{"name": "consent.pdf", "content": encoded}]
+)
+print(response.status_code)  # 201
+```
+
+---
+
+## Error Handling
+
+All client methods raise `requests.exceptions.HTTPError` on non-2xx responses. The `handle_error` helper (`paubox.helpers.errors`) prints the error response body to stdout before re-raising, which aids debugging.
+
+```python
+import requests
+import paubox
+
+client = paubox.PauboxFormsClient()
+try:
+    response = client.get_form("nonexistent-uuid")
+except requests.exceptions.HTTPError as e:
+    print(e.response.status_code)  # 404
+```
+
+`submit_form` additionally raises `ValueError` before any network call if `form_data` is falsy:
+
+```python
+try:
+    client.submit_form("form-uuid", form_data=None)
+except ValueError as e:
+    print(e)  # "form_data is required and must not be empty"
+```
+
+---
+
+## Mail Helper — `Mail`
+
+Convenience class for building Email API message dicts. Located in `paubox.helpers.mail`.
+
+### Constructor
+
+```python
+Mail(from_, subject, recipients, content, optional_headers=None)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `from_` | `str` | Sender email address |
+| `subject` | `str` | Email subject |
+| `recipients` | `list[str]` | List of recipient email addresses |
+| `content` | `dict` | `{"text/plain": "...", "text/html": "..."}`. HTML is auto-encoded to base64. |
+| `optional_headers` | `dict` or `None` | See table below |
+
+**Optional headers**
+
+| Key | Type | Description |
+|---|---|---|
+| `reply_to` | `str` | Reply-to address |
+| `bcc` | `str` or `list` | BCC recipient(s) |
+| `cc` | `list[str]` | CC recipients |
+| `attachments` | `list[dict]` | Each dict: `{"fileName": "...", "contentType": "...", "content": "<base64>"}` |
+| `forceSecureNotification` | `bool` or `str` | Send as secure portal notification |
+| `allowNonTLS` | `bool` | Allow delivery without TLS (non-PHI only) |
+
+### `get()`
+
+Returns the formatted message dict ready to pass to `PauboxApiClient.send()`.

--- a/paubox/__init__.py
+++ b/paubox/__init__.py
@@ -4,4 +4,5 @@ API application and get the email disposition of sent emails.
 """
 
 from .paubox import PauboxApiClient, Response
+from .forms import PauboxFormsClient
 NAME = "paubox"

--- a/paubox/forms.py
+++ b/paubox/forms.py
@@ -1,0 +1,79 @@
+"""
+Paubox Forms API client.
+Public endpoints for retrieving form definitions and submitting responses.
+No authentication is required for these endpoints.
+"""
+
+import requests
+from .paubox import Response
+from .helpers.errors import handle_error
+
+FORMS_BASE_URL = "https://next.paubox.com"
+
+
+class PauboxFormsClient(object):
+    """Client for the Paubox Forms API (public endpoints, no authentication required)."""
+
+    def __init__(self, base_url=FORMS_BASE_URL):
+        """
+        :param base_url: Forms API base URL. Defaults to https://next.paubox.com.
+        :type base_url: str
+        """
+        self.base_url = base_url
+
+    def get_form(self, form_id):
+        """
+        Retrieve a form's metadata, HTML, JSON schema, and CSS by UUID.
+
+        GET /public/form_data/{form_id}
+
+        :param form_id: UUID of the form to retrieve.
+        :type form_id: str
+        :returns: Response containing the form definition.
+        :rtype: Response
+        :raises requests.exceptions.HTTPError: on 404 or other HTTP errors.
+        """
+        url = f"{self.base_url}/public/form_data/{form_id}"
+        try:
+            response = requests.get(url, headers={"Content-Type": "application/json"})
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def submit_form(self, form_id, form_data, attachments=None):
+        """
+        Submit a respondent's answers for a form.
+
+        POST /api/forms/{form_id}/submissions
+
+        Maximum request size is 250 MB (to support file attachments).
+
+        :param form_id: UUID of the form being submitted.
+        :type form_id: str
+        :param form_data: Key-value pairs matching the form's field schema.
+        :type form_data: dict
+        :param attachments: Optional list of dicts with 'name' (filename) and
+            'content' (base64-encoded file content).
+        :type attachments: list or None
+        :returns: Response with status 201 and no body on success.
+        :rtype: Response
+        :raises ValueError: if form_data is None or empty.
+        :raises requests.exceptions.HTTPError: on 400, 404, or other HTTP errors.
+        """
+        if not form_data:
+            raise ValueError("form_data is required and must not be empty")
+
+        url = f"{self.base_url}/api/forms/{form_id}/submissions"
+        payload = {"form_data": form_data}
+        if attachments:
+            payload["attachments"] = attachments
+
+        try:
+            response = requests.post(
+                url, json=payload, headers={"Content-Type": "application/json"}
+            )
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="paubox-python3",
-    version="1.0.1",
+    version="1.1.0",
     author="Paubox",
     author_email="info@paubox.com",
-    description="Python3 SDK for Paubox Email REST API",
+    description="Python3 SDK for Paubox Email and Forms REST APIs",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Paubox/paubox-python3",

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,194 @@
+"""
+Unit tests for PauboxFormsClient.
+No real HTTP calls are made — all network I/O is patched with unittest.mock.
+No credentials or config.cfg required.
+"""
+import unittest
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+import requests
+
+from paubox.forms import PauboxFormsClient, FORMS_BASE_URL
+
+TestCase.maxDiff = None
+
+FORM_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _mock_response(status_code=200, text="", raise_for_status=None):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.headers = {"Content-Type": "application/json"}
+    mock.text = text
+    if raise_for_status:
+        mock.raise_for_status.side_effect = raise_for_status
+    else:
+        mock.raise_for_status.return_value = None
+    return mock
+
+
+def _http_error(status_code):
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = f'{{"error": "HTTP {status_code}"}}'
+    err = requests.exceptions.HTTPError(response=response)
+    return err
+
+
+class TestPauboxFormsClientInit(TestCase):
+    """Tests for PauboxFormsClient constructor."""
+
+    def test_default_base_url(self):
+        client = PauboxFormsClient()
+        self.assertEqual(client.base_url, FORMS_BASE_URL)
+        self.assertEqual(client.base_url, "https://next.paubox.com")
+
+    def test_custom_base_url(self):
+        client = PauboxFormsClient(base_url="http://localhost:3000")
+        self.assertEqual(client.base_url, "http://localhost:3000")
+
+
+class TestGetForm(TestCase):
+    """Tests for PauboxFormsClient.get_form."""
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_success(self, mock_get):
+        body = (
+            '{"id": "550e8400-e29b-41d4-a716-446655440000", "title": "Patient Intake Form",'
+            '"active": true, "submission_count": 42}'
+        )
+        mock_get.return_value = _mock_response(status_code=200, text=body)
+
+        client = PauboxFormsClient()
+        response = client.get_form(FORM_ID)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.to_dict
+        self.assertEqual(data["id"], FORM_ID)
+        self.assertEqual(data["title"], "Patient Intake Form")
+        self.assertTrue(data["active"])
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_calls_correct_url(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(base_url="https://next.paubox.com")
+        client.get_form(FORM_ID)
+        mock_get.assert_called_once_with(
+            f"https://next.paubox.com/public/form_data/{FORM_ID}",
+            headers={"Content-Type": "application/json"},
+        )
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_sends_no_auth_header(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient()
+        client.get_form(FORM_ID)
+        _, kwargs = mock_get.call_args
+        headers = kwargs.get("headers", {})
+        self.assertNotIn("Authorization", headers)
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_not_found_raises_http_error(self, mock_get):
+        mock_get.return_value = _mock_response(
+            status_code=404, raise_for_status=_http_error(404)
+        )
+        client = PauboxFormsClient()
+        with self.assertRaises(requests.exceptions.HTTPError):
+            client.get_form(FORM_ID)
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_returns_response_object(self, mock_get):
+        from paubox.paubox import Response
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient()
+        response = client.get_form(FORM_ID)
+        self.assertIsInstance(response, Response)
+
+
+class TestSubmitForm(TestCase):
+    """Tests for PauboxFormsClient.submit_form."""
+
+    @patch("paubox.forms.requests.post")
+    def test_submit_form_success(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=201, text="")
+        client = PauboxFormsClient()
+        response = client.submit_form(FORM_ID, form_data={"first_name": "Jane"})
+        self.assertEqual(response.status_code, 201)
+        self.assertIsNone(response.to_dict)
+
+    @patch("paubox.forms.requests.post")
+    def test_submit_form_calls_correct_url(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=201, text="")
+        client = PauboxFormsClient(base_url="https://next.paubox.com")
+        client.submit_form(FORM_ID, form_data={"x": "y"})
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], f"https://next.paubox.com/api/forms/{FORM_ID}/submissions")
+
+    @patch("paubox.forms.requests.post")
+    def test_submit_form_sends_no_auth_header(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=201, text="")
+        client = PauboxFormsClient()
+        client.submit_form(FORM_ID, form_data={"x": "y"})
+        _, kwargs = mock_post.call_args
+        headers = kwargs.get("headers", {})
+        self.assertNotIn("Authorization", headers)
+
+    @patch("paubox.forms.requests.post")
+    def test_submit_form_payload_includes_form_data(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=201, text="")
+        client = PauboxFormsClient()
+        form_data = {"first_name": "Jane", "last_name": "Doe"}
+        client.submit_form(FORM_ID, form_data=form_data)
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs["json"]["form_data"], form_data)
+
+    @patch("paubox.forms.requests.post")
+    def test_submit_form_with_attachments(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=201, text="")
+        client = PauboxFormsClient()
+        attachments = [{"name": "consent.pdf", "content": "JVBERi0xLjQ="}]
+        client.submit_form(FORM_ID, form_data={"sig": "x"}, attachments=attachments)
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs["json"]["attachments"], attachments)
+
+    @patch("paubox.forms.requests.post")
+    def test_submit_form_without_attachments_omits_key(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=201, text="")
+        client = PauboxFormsClient()
+        client.submit_form(FORM_ID, form_data={"x": "y"})
+        _, kwargs = mock_post.call_args
+        self.assertNotIn("attachments", kwargs["json"])
+
+    def test_submit_form_raises_value_error_on_empty_form_data(self):
+        client = PauboxFormsClient()
+        with self.assertRaises(ValueError):
+            client.submit_form(FORM_ID, form_data={})
+
+    def test_submit_form_raises_value_error_on_none_form_data(self):
+        client = PauboxFormsClient()
+        with self.assertRaises(ValueError):
+            client.submit_form(FORM_ID, form_data=None)
+
+    @patch("paubox.forms.requests.post")
+    def test_submit_form_http_error_400(self, mock_post):
+        mock_post.return_value = _mock_response(
+            status_code=400, raise_for_status=_http_error(400)
+        )
+        client = PauboxFormsClient()
+        with self.assertRaises(requests.exceptions.HTTPError):
+            client.submit_form(FORM_ID, form_data={"x": "y"})
+
+    @patch("paubox.forms.requests.post")
+    def test_submit_form_http_error_404(self, mock_post):
+        mock_post.return_value = _mock_response(
+            status_code=404, raise_for_status=_http_error(404)
+        )
+        client = PauboxFormsClient()
+        with self.assertRaises(requests.exceptions.HTTPError):
+            client.submit_form(FORM_ID, form_data={"x": "y"})
+
+
+SUITE = unittest.TestLoader().loadTestsFromModule(__import__(__name__))
+if __name__ == "__main__":
+    unittest.TextTestRunner(verbosity=2).run(SUITE)


### PR DESCRIPTION
- Add PauboxFormsClient in paubox/forms.py with get_form() and submit_form()
- Forms endpoints use https://next.paubox.com with no authentication required
- Export PauboxFormsClient from top-level paubox package
- Add 17 unit tests in tests/test_forms.py (no credentials needed)
- Add CLAUDE.md project guide and api.md full API reference
- Update README.md with Forms API section and examples
- Bump version to 1.1.0 in setup.py and update CHANGELOG.md

https://claude.ai/code/session_01LpLSqej8NFzhbejBopwT6F