### PR TITLE
Add Paubox Forms API support (v1.1.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ PYTHONPATH=. python tests/test_paubox.py
 
 - **`Response` class lives in `paubox/paubox.py`** and is imported by `forms.py` to avoid a breaking change. If you move it, update all importers.
 - **`PauboxFormsClient` accepts an optional `base_url`** constructor argument for test injection (no real HTTP calls in unit tests).
-- **Forms endpoints use `https://next.paubox.com`**; Email endpoints use a per-customer host set via `PAUBOX_HOST`.
+- **Forms endpoints use `https://apx.paubox.com/forms`**; Email endpoints use a per-customer host set via `PAUBOX_HOST`.
 - **No auth headers are sent for Forms API calls** — these are public endpoints called by form respondents.
 - **`submit_form` validates `form_data` locally** before making the network call, raising `ValueError` if it is falsy (mirrors the API's 400 response).
 
@@ -66,7 +66,7 @@ PYTHONPATH=. python tests/test_paubox.py
 | `PAUBOX_API_KEY` | `PauboxApiClient` | Paubox Email API key |
 | `PAUBOX_HOST` | `PauboxApiClient` | Email API base URL (e.g. `https://api.paubox.net/v1/your-endpoint`) |
 
-`PauboxFormsClient` has no required environment variables; its base URL defaults to `https://next.paubox.com`.
+`PauboxFormsClient` has no required environment variables; its base URL defaults to `https://apx.paubox.com/forms`.
 
 ## Adding a New API Surface
 

--- a/api.md
+++ b/api.md
@@ -7,7 +7,7 @@ The SDK exposes two independent clients and a shared `Response` class:
 | Class | Module | Auth required | Base URL |
 |---|---|---|---|
 | `PauboxApiClient` | `paubox.paubox` | Yes — `Token token=<key>` | Per-customer (`PAUBOX_HOST`) |
-| `PauboxFormsClient` | `paubox.forms` | No | `https://next.paubox.com` |
+| `PauboxFormsClient` | `paubox.forms` | No | `https://apx.paubox.com/forms` |
 | `Response` | `paubox.paubox` | — | — |
 
 All three are importable directly from the top-level package:
@@ -108,12 +108,12 @@ These are **public endpoints** — no API key is required. They are intended to 
 ### Constructor
 
 ```python
-PauboxFormsClient(base_url="https://next.paubox.com")
+PauboxFormsClient(base_url="https://apx.paubox.com/forms")
 ```
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `base_url` | `str` | `"https://next.paubox.com"` | Forms API base URL. Override for testing. |
+| `base_url` | `str` | `"https://apx.paubox.com/forms"` | Forms API base URL. Override for testing. |
 
 ### `get_form(form_id)`
 

--- a/paubox/forms.py
+++ b/paubox/forms.py
@@ -8,7 +8,7 @@ import requests
 from .paubox import Response
 from .helpers.errors import handle_error
 
-FORMS_BASE_URL = "https://next.paubox.com"
+FORMS_BASE_URL = "https://apx.paubox.com/forms"
 
 
 class PauboxFormsClient(object):
@@ -16,7 +16,7 @@ class PauboxFormsClient(object):
 
     def __init__(self, base_url=FORMS_BASE_URL):
         """
-        :param base_url: Forms API base URL. Defaults to https://next.paubox.com.
+        :param base_url: Forms API base URL. Defaults to https://apx.paubox.com/forms.
         :type base_url: str
         """
         self.base_url = base_url

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -41,7 +41,7 @@ class TestPauboxFormsClientInit(TestCase):
     def test_default_base_url(self):
         client = PauboxFormsClient()
         self.assertEqual(client.base_url, FORMS_BASE_URL)
-        self.assertEqual(client.base_url, "https://next.paubox.com")
+        self.assertEqual(client.base_url, "https://apx.paubox.com/forms")
 
     def test_custom_base_url(self):
         client = PauboxFormsClient(base_url="http://localhost:3000")
@@ -71,10 +71,10 @@ class TestGetForm(TestCase):
     @patch("paubox.forms.requests.get")
     def test_get_form_calls_correct_url(self, mock_get):
         mock_get.return_value = _mock_response(status_code=200, text="{}")
-        client = PauboxFormsClient(base_url="https://next.paubox.com")
+        client = PauboxFormsClient(base_url="https://apx.paubox.com/forms")
         client.get_form(FORM_ID)
         mock_get.assert_called_once_with(
-            f"https://next.paubox.com/public/form_data/{FORM_ID}",
+            f"https://apx.paubox.com/forms/public/form_data/{FORM_ID}",
             headers={"Content-Type": "application/json"},
         )
 
@@ -119,11 +119,11 @@ class TestSubmitForm(TestCase):
     @patch("paubox.forms.requests.post")
     def test_submit_form_calls_correct_url(self, mock_post):
         mock_post.return_value = _mock_response(status_code=201, text="")
-        client = PauboxFormsClient(base_url="https://next.paubox.com")
+        client = PauboxFormsClient(base_url="https://apx.paubox.com/forms")
         client.submit_form(FORM_ID, form_data={"x": "y"})
         mock_post.assert_called_once()
         args, kwargs = mock_post.call_args
-        self.assertEqual(args[0], f"https://next.paubox.com/api/forms/{FORM_ID}/submissions")
+        self.assertEqual(args[0], f"https://apx.paubox.com/forms/api/forms/{FORM_ID}/submissions")
 
     @patch("paubox.forms.requests.post")
     def test_submit_form_sends_no_auth_header(self, mock_post):


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `PauboxFormsClient` in `paubox/forms.py` with two public endpoints (no API key required):
  - `get_form(form_id)` — `GET /public/form_data/{form_id}` — retrieves form metadata, HTML, JSON schema, and CSS
  - `submit_form(form_id, form_data, attachments=None)` — `POST /api/forms/{form_id}/submissions` — submits form data with optional base64 file attachments (up to 250 MB)
- Export `PauboxFormsClient` from the top-level `paubox` package
- Add 17 unit tests in `tests/test_forms.py` (no credentials or `config.cfg` required)
- Add `CLAUDE.md` project guide and `api.md` full API reference
- Update `README.md` with Forms API section and code examples
- Bump version to `1.1.0` in `setup.py`
- Base URL set to `https://apx.paubox.com/forms`

## Test plan

- [ ] `PYTHONPATH=. python tests/test_forms.py` — all 17 unit tests pass
- [ ] `PYTHONPATH=. python -c "import paubox; c = paubox.PauboxFormsClient(); print(c.base_url)"` — prints `https://apx.paubox.com/forms`
- [ ] Existing email API tests unaffected (`PauboxApiClient` and `Response` unchanged)

https://claude.ai/code/session_01LpLSqej8NFzhbejBopwT6F
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpLSqej8NFzhbejBopwT6F)_