### PR TITLE
feat: add authenticated Forms API support via scoped API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# v1.2.0 / 2026-08-11
+### 🚀 New Features
+- Add authenticated Paubox Forms endpoints to `PauboxFormsClient` (scoped API keys with the `forms` scope, sent as `Authorization: Bearer <key>`; JWTs also accepted)
+  - `PauboxFormsClient(base_url, api_key=None)` — new optional `api_key` constructor argument (backward compatible)
+  - Form management: `list_forms(...)`, `get_form_by_id(form_id)`, `create_form(...)`, `update_form(...)`, `archive_form(form_id)`, `unarchive_form(form_id)`, `copy_form(form_id, title)`, `get_form_stats(customer_id=None)`
+  - Submissions: `list_submissions(...)`, `export_submissions_csv(form_id, submission_id=None)`, `export_submission_pdf(form_id, submission_id)`
+- Add `Response.content` property exposing the raw response bytes (for CSV/PDF exports)
+- Existing public endpoints (`get_form`, `submit_form`) are unchanged and still send no auth headers
+- Add unit tests for all new methods (no live credentials required)
+
 # v1.1.0 / 2026-05-21
 ### 🚀 New Features
 - Add `PauboxFormsClient` with support for the Paubox Forms API (public endpoints, no API key required)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ All notable changes to this project will be documented in this file.
   - Form management: `list_forms(...)`, `get_form_by_id(form_id)`, `create_form(...)`, `update_form(...)`, `archive_form(form_id)`, `unarchive_form(form_id)`, `copy_form(form_id, title)`, `get_form_stats(customer_id=None)`
   - Submissions: `list_submissions(...)`, `export_submissions_csv(form_id, submission_id=None)`, `export_submission_pdf(form_id, submission_id)`
 - Add `Response.content` property exposing the raw response bytes (for CSV/PDF exports)
-- Existing public endpoints (`get_form`, `submit_form`) are unchanged and still send no auth headers
+- Existing public endpoints (`get_form`, `submit_form`) still send no auth headers
 - Add unit tests for all new methods (no live credentials required)
+
+### 🔒 Hardening
+- Validate every caller-supplied value interpolated into a request URL path. A `form_id` or `submission_id` containing `..`, `/`, `?` or `#` would otherwise change which endpoint is called: `requests` resolves dot-segments while preparing a URL, so the retargeting happens client-side, and a rewritten path can leave the `/forms` base path on the same host and carry the `Authorization` header with it.
+  - Authenticated endpoints raise `ValueError` unless the id is a UUID.
+  - `get_form` and `submit_form` percent-encode the id rather than rejecting it, so any id they accepted before still works. The bare dot-segments `.` and `..` are rejected, because encoding cannot neutralize them — `quote()` leaves `.` alone and `requests` un-escapes `%2E` during preparation.
+- No published release was affected: the newest version on PyPI predates `PauboxFormsClient`, and 1.1.0 was never published.
 
 # v1.1.0 / 2026-05-21
 ### 🚀 New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 Python3 SDK for Paubox APIs. Provides two independent clients:
 
 - **`PauboxApiClient`** — HIPAA-compliant transactional email (requires API key)
-- **`PauboxFormsClient`** — public form retrieval and submission (no auth required)
+- **`PauboxFormsClient`** — form retrieval and submission (public, no auth) plus form management and submission export (requires a scoped API key)
 
 ## Directory Structure
 
@@ -54,9 +54,9 @@ PYTHONPATH=. python tests/test_paubox.py
 ## Key Design Decisions
 
 - **`Response` class lives in `paubox/paubox.py`** and is imported by `forms.py` to avoid a breaking change. If you move it, update all importers.
-- **`PauboxFormsClient` accepts an optional `base_url`** constructor argument for test injection (no real HTTP calls in unit tests).
+- **`PauboxFormsClient` accepts an optional `base_url`** constructor argument for test injection (no real HTTP calls in unit tests), and an optional `api_key` argument for the authenticated endpoints.
 - **Forms endpoints use `https://apx.paubox.com/forms`**; Email endpoints use a per-customer host set via `PAUBOX_HOST`.
-- **No auth headers are sent for Forms API calls** — these are public endpoints called by form respondents.
+- **Public Forms endpoints (`get_form`, `submit_form`) send no auth headers** — they are called by form respondents. The management and submission-export endpoints send `Authorization: Bearer <scoped api key>` (a Paubox scoped API key with the `forms` scope; JWTs also accepted).
 - **`submit_form` validates `form_data` locally** before making the network call, raising `ValueError` if it is falsy (mirrors the API's 400 response).
 
 ## Environment Variables

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Paubox Email API allows your application to send secure, HIPAA compliant ema
    *  [Sending Email](#sending-messages-with-the-paubox-mail-helper)
    *  [Checking Email Dispositions](#checking-email-dispositions)
    *  [Paubox Forms API](#paubox-forms-api)
+   *  [Paubox Forms — authenticated endpoints (scoped API keys)](#paubox-forms-authenticated)
 *  [Contributing](#contributing)
 *  [License](#license)
 
@@ -393,6 +394,95 @@ response = forms_client.submit_form(
     attachments=[{"name": "consent.pdf", "content": encoded}]
 )
 print(response.status_code)   # 201
+```
+
+<a name="#paubox-forms-authenticated"></a>
+## Paubox Forms — authenticated endpoints (scoped API keys)
+
+Beyond the public endpoints above, `PauboxFormsClient` can manage forms and retrieve/export submissions. These endpoints require authentication:
+
+*  Pass a **Paubox scoped API key** carrying the **`forms` scope** as the `api_key` constructor argument. The key is sent as a Bearer token (`Authorization: Bearer <key>`) on every authenticated call. JWTs are also accepted.
+*  The public endpoints (`get_form`, `submit_form`) never send auth headers, even when `api_key` is set.
+*  Calling an authenticated method without an `api_key` raises `ValueError` before any network call.
+
+```python
+import paubox
+
+forms_client = paubox.PauboxFormsClient(api_key="YOUR_SCOPED_API_KEY")
+```
+
+### Managing Forms
+
+```python
+import paubox
+
+forms_client = paubox.PauboxFormsClient(api_key="YOUR_SCOPED_API_KEY")
+
+# List forms (paginated; pass the customer_id your key is scoped to —
+# API-key calls that omit it are rejected with 403 Forbidden)
+response = forms_client.list_forms(customer_id=12345, search="intake", order="asc", order_by="title", page=1, items=25)
+print(response.to_dict["results"])      # list of forms
+print(response.to_dict["page_info"])    # {"count", "pages", "page", "items"}
+
+# Get a single form (authenticated variant of get_form)
+response = forms_client.get_form_by_id("your-form-uuid-here")
+print(response.to_dict["data"])
+
+# Create a form
+response = forms_client.create_form(
+    title="Patient Intake Form",
+    form_json={"fields": [{"name": "first_name", "type": "text"}]},
+    customer_id=12345,
+    description="New patient intake",
+    recipient="intake@yourdomain.com,frontdesk@yourdomain.com",
+    active=True
+)
+print(response.to_dict["id"])           # UUID of the new form
+
+# Update a form — only the arguments you pass are changed
+response = forms_client.update_form("your-form-uuid-here", title="Updated Title", active=False)
+print(response.to_dict["detail"])       # "Form updated successfully"
+
+# Archive / unarchive (archiving also deactivates the form)
+forms_client.archive_form("your-form-uuid-here")
+forms_client.unarchive_form("your-form-uuid-here")
+
+# Copy a form
+response = forms_client.copy_form("your-form-uuid-here", "Copy of Patient Intake Form")
+print(response.to_dict["id"])           # UUID of the copy
+
+# Form stats
+response = forms_client.get_form_stats()
+print(response.to_dict)                 # {"active_form_count", "total_submission_count", "submissions_last_7_days"}
+```
+
+### Retrieving and Exporting Submissions
+
+```python
+import paubox
+
+forms_client = paubox.PauboxFormsClient(api_key="YOUR_SCOPED_API_KEY")
+
+# List a form's submissions (paginated)
+response = forms_client.list_submissions("your-form-uuid-here", page=1, items=50)
+for submission in response.to_dict["data"]:
+    print(submission["id"], submission["submitter_email"])
+    print(submission["form_data"])      # JSON string — parse with json.loads if needed
+
+# Export all submissions as CSV
+response = forms_client.export_submissions_csv("your-form-uuid-here")
+with open("submissions.csv", "wb") as f:
+    f.write(response.content)
+
+# Export a single submission as CSV
+response = forms_client.export_submissions_csv("your-form-uuid-here", "submission-uuid-here")
+with open("submission.csv", "wb") as f:
+    f.write(response.content)
+
+# Export a single submission as PDF
+response = forms_client.export_submission_pdf("your-form-uuid-here", "submission-uuid-here")
+with open("submission.pdf", "wb") as f:
+    f.write(response.content)
 ```
 
 <a name="#contributing"></a>

--- a/api.md
+++ b/api.md
@@ -7,7 +7,7 @@ The SDK exposes two independent clients and a shared `Response` class:
 | Class | Module | Auth required | Base URL |
 |---|---|---|---|
 | `PauboxApiClient` | `paubox.paubox` | Yes — `Token token=<key>` | Per-customer (`PAUBOX_HOST`) |
-| `PauboxFormsClient` | `paubox.forms` | No | `https://apx.paubox.com/forms` |
+| `PauboxFormsClient` | `paubox.forms` | Public endpoints: no. Management/export endpoints: yes — `Bearer <scoped api key>` | `https://apx.paubox.com/forms` |
 | `Response` | `paubox.paubox` | — | — |
 
 All three are importable directly from the top-level package:
@@ -32,6 +32,7 @@ Wraps a `requests.Response` object returned by all client methods.
 | `status_code` | `int` | HTTP status code |
 | `headers` | `dict` | Response headers |
 | `text` | `str` | Raw response body |
+| `content` | `bytes` | Raw response body as bytes — use for binary responses (CSV/PDF exports) |
 | `to_dict` | `dict` or `None` | Response body parsed as JSON; `None` if body is empty |
 
 ---
@@ -103,17 +104,21 @@ Authorization: Token token={api_key}
 
 ## Forms API — `PauboxFormsClient`
 
-These are **public endpoints** — no API key is required. They are intended to be called by form respondents (or on their behalf).
+The Forms API has two kinds of endpoints:
+
+- **Public endpoints** (`get_form`, `submit_form`) — no API key is required. They are intended to be called by form respondents (or on their behalf), and never send auth headers even when the client has an `api_key`.
+- **Authenticated endpoints** (everything else) — require a **Paubox scoped API key** with the **`forms` scope**, sent as `Authorization: Bearer <api_key>`. JWTs are also accepted. Calling an authenticated method without an `api_key` raises `ValueError` before any network call.
 
 ### Constructor
 
 ```python
-PauboxFormsClient(base_url="https://apx.paubox.com/forms")
+PauboxFormsClient(base_url="https://apx.paubox.com/forms", api_key=None)
 ```
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `base_url` | `str` | `"https://apx.paubox.com/forms"` | Forms API base URL. Override for testing. |
+| `api_key` | `str` or `None` | `None` | Paubox scoped API key with the `forms` scope (or a JWT). Required only for authenticated endpoints. |
 
 ### `get_form(form_id)`
 
@@ -216,6 +221,353 @@ response = client.submit_form(
 print(response.status_code)  # 201
 ```
 
+### `list_forms(customer_id=None, form_id=None, search=None, order=None, order_by=None, archived=None, active=None, page=None, items=None)`
+
+**Authenticated.** List forms visible to the API key, with filtering, ordering, and pagination.
+
+```
+GET {base_url}/api/forms
+Authorization: Bearer {api_key}
+```
+
+**Parameters** (all optional; `None` values are omitted from the query string; booleans are serialized as lowercase `"true"`/`"false"`)
+
+| Parameter | Type | Description |
+|---|---|---|
+| `customer_id` | `int` or `None` | Customer whose forms to list. Effectively required for API-key callers — the server returns 403 Forbidden when omitted. Pass the customer ID your key is scoped to (or a related customer's) |
+| `form_id` | `str` or `None` | Filter to a single form UUID |
+| `search` | `str` or `None` | Matches against form title and description |
+| `order` | `str` or `None` | `"asc"` or `"desc"` (default `"desc"`) |
+| `order_by` | `str` or `None` | One of `title`, `updated_at`, `submission_count`; anything else falls back to `created_at` |
+| `archived` | `bool` or `None` | Filter by archived state |
+| `active` | `bool` or `None` | Filter by active state |
+| `page` | `int` or `None` | Page number (default 1) |
+| `items` | `int` or `None` | Items per page (default 50, server caps at 100) |
+
+**Returns** `Response` — `response.to_dict`:
+
+| Field | Type | Description |
+|---|---|---|
+| `results` | `list` | List of form objects |
+| `page_info` | `object` | `{"count", "pages", "page", "items"}` |
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on auth failure or other HTTP errors.
+
+**Example**
+
+```python
+import paubox
+
+client = paubox.PauboxFormsClient(api_key="YOUR_SCOPED_API_KEY")
+response = client.list_forms(customer_id=12345, search="intake", order="asc", order_by="title", items=25)
+for form in response.to_dict["results"]:
+    print(form["title"])
+```
+
+### `get_form_by_id(form_id)`
+
+**Authenticated.** Retrieve a single form — the authenticated variant of the public `get_form`.
+
+```
+GET {base_url}/api/forms/{form_id}
+Authorization: Bearer {api_key}
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `form_id` | `str` | UUID of the form to retrieve |
+
+**Returns** `Response` — `response.to_dict` is `{"data": {...form...}}`.
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on 404 (form not found) or other HTTP errors.
+
+### `create_form(title, form_json, customer_id, description=None, form_html=None, form_css=None, recipient=None, signable=False, signature_confirmation_label=None, subscription_list_id=None, form_type=None, active=False, version=1, submission_count=0)`
+
+**Authenticated.** Create a new form.
+
+```
+POST {base_url}/api/forms
+Authorization: Bearer {api_key}
+```
+
+**Parameters** (optional parameters that are `None` are omitted from the JSON body)
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `title` | `str` | Yes | Form title |
+| `form_json` | `dict` | Yes | Form definition (JSON schema of form fields) |
+| `customer_id` | `int` | Yes | Owning customer ID |
+| `description` | `str` or `None` | No | Form description |
+| `form_html` | `str` or `None` | No | Rendered HTML for embedding |
+| `form_css` | `str` or `None` | No | CSS for the form |
+| `recipient` | `str` or `None` | No | Comma-separated string of notification email addresses |
+| `signable` | `bool` | No | Whether the form supports signatures (default `False`) |
+| `signature_confirmation_label` | `str` or `None` | No | Label for the signature confirmation checkbox |
+| `subscription_list_id` | `str` or `None` | No | Subscription list to attach |
+| `form_type` | `str` or `None` | No | Form type — sent as the JSON key `"type"` |
+| `active` | `bool` | No | Whether the form accepts submissions (default `False`) |
+| `version` | `int` | No | Form version (default `1`) |
+| `submission_count` | `int` | No | Initial submission count (default `0`) |
+
+**Returns** `Response` — `response.to_dict` is `{"id": "<new-uuid>"}`.
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on validation or other HTTP errors.
+
+**Example**
+
+```python
+import paubox
+
+client = paubox.PauboxFormsClient(api_key="YOUR_SCOPED_API_KEY")
+response = client.create_form(
+    title="Patient Intake Form",
+    form_json={"fields": [{"name": "first_name", "type": "text"}]},
+    customer_id=12345,
+    recipient="intake@yourdomain.com",
+    active=True
+)
+new_form_id = response.to_dict["id"]
+```
+
+### `update_form(form_id, title=None, description=None, form_json=None, vanity_url=None, recipient=None, active=None, subscription_list_id=None)`
+
+**Authenticated.** Update a form. PATCH-style merge on the server: only keys present in the body are changed, so the SDK includes only the arguments that are not `None`.
+
+```
+PUT {base_url}/api/forms/{form_id}
+Authorization: Bearer {api_key}
+```
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `form_id` | `str` | Yes | UUID of the form to update |
+| `title` | `str` or `None` | No | New title |
+| `description` | `str` or `None` | No | New description |
+| `form_json` | `dict` or `None` | No | New form definition |
+| `vanity_url` | `str` or `None` | No | New vanity URL. Note: the server currently accepts this field but does not persist it — the value is silently ignored even though the call returns 200 |
+| `recipient` | `str` or `None` | No | Comma-separated notification email addresses |
+| `active` | `bool` or `None` | No | Activate/deactivate the form |
+| `subscription_list_id` | `str` or `None` | No | Subscription list to attach |
+
+**Returns** `Response` — `response.to_dict` is `{"detail": "Form updated successfully", "form_id": "<id>"}`.
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on 404 (form not found) or other HTTP errors.
+
+### `archive_form(form_id)`
+
+**Authenticated.** Archive a form (archiving also deactivates the form server-side).
+
+```
+POST {base_url}/api/forms/{form_id}/archive
+Authorization: Bearer {api_key}
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `form_id` | `str` | UUID of the form to archive |
+
+**Returns** `Response` — `response.to_dict` is `{"detail": "Form archived."}`.
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on 404 (form not found) or other HTTP errors.
+
+### `unarchive_form(form_id)`
+
+**Authenticated.** Unarchive a form.
+
+```
+POST {base_url}/api/forms/{form_id}/unarchive
+Authorization: Bearer {api_key}
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `form_id` | `str` | UUID of the form to unarchive |
+
+**Returns** `Response` — `response.to_dict` is `{"detail": "Form unarchived."}`.
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on 404 (form not found) or other HTTP errors.
+
+### `copy_form(form_id, title)`
+
+**Authenticated.** Copy an existing form under a new title.
+
+```
+POST {base_url}/api/forms/copy
+Authorization: Bearer {api_key}
+```
+
+**Body** `{"form_id": "<source-uuid>", "title": "<new title>"}`
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `form_id` | `str` | UUID of the source form |
+| `title` | `str` | Title for the copy |
+
+**Returns** `Response` — `response.to_dict` is the full new form object (fresh UUID, `vanity_url` cleared, `submission_count` 0).
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on 404 (source form not found) or other HTTP errors.
+
+### `get_form_stats(customer_id=None)`
+
+**Authenticated.** Retrieve aggregate form statistics.
+
+```
+GET {base_url}/api/forms/stats
+Authorization: Bearer {api_key}
+```
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `customer_id` | `int` or `None` | No | Customer to report on (defaults server-side to the key's customer) |
+
+**Returns** `Response` — `response.to_dict`:
+
+| Field | Type | Description |
+|---|---|---|
+| `active_form_count` | `int` | Number of active forms |
+| `total_submission_count` | `int` | Total submissions across all forms |
+| `submissions_last_7_days` | `int` | Submissions received in the last 7 days |
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on auth failure or other HTTP errors.
+
+### `list_submissions(form_id, submission_id=None, order_by=None, order=None, page=None, items=None)`
+
+**Authenticated.** List a form's submissions, with ordering and pagination.
+
+```
+GET {base_url}/api/forms/{form_id}/submissions
+Authorization: Bearer {api_key}
+```
+
+**Parameters** (`None` values are omitted from the query string)
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `form_id` | `str` | Yes | UUID of the form |
+| `submission_id` | `str` or `None` | No | Filter to a single submission UUID |
+| `order_by` | `str` or `None` | No | `submitter_email`; anything else falls back to `created_at` |
+| `order` | `str` or `None` | No | `"asc"` or `"desc"` |
+| `page` | `int` or `None` | No | Page number |
+| `items` | `int` or `None` | No | Items per page (server caps at 100) |
+
+**Returns** `Response` — `response.to_dict` is `{"data": [submission...], "total", "page", "items"}`. Each submission object:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `str` (UUID) | Submission UUID |
+| `form_id` | `str` (UUID) | Parent form UUID |
+| `form_data` | `str` | Submitted data as a JSON **string** — parse with `json.loads` |
+| `storage_type` | `str` or `null` | Storage backend for the submission |
+| `storage_url` | `str` or `null` | Storage location URL |
+| `submitter_email` | `str` or `null` | Respondent's email address |
+| `recipients` | `str` or `null` | Notification recipients |
+| `attachment_name` | `str` or `null` | Attachment filename |
+| `attachment_url` | `str` or `null` | Attachment URL |
+| `attachment_type` | `str` or `null` | Attachment content type |
+| `created_at` | `str` (ISO 8601) | Submission timestamp |
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on 404 (form not found) or other HTTP errors.
+
+### `export_submissions_csv(form_id, submission_id=None)`
+
+**Authenticated.** Export a form's submissions as CSV — all submissions, or a single one.
+
+```
+GET {base_url}/api/forms/{form_id}/submissions/submission-csv                    # all submissions
+GET {base_url}/api/forms/{form_id}/submissions/submission-csv/{submission_id}    # single submission
+Authorization: Bearer {api_key}
+```
+
+**Parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `form_id` | `str` | Yes | UUID of the form |
+| `submission_id` | `str` or `None` | No | Export a single submission instead of all |
+
+**Returns** `Response` — CSV bytes (`text/csv`, attachment). Use `response.content` for the bytes.
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on 404 (form or submission not found) or other HTTP errors.
+
+**Example**
+
+```python
+import paubox
+
+client = paubox.PauboxFormsClient(api_key="YOUR_SCOPED_API_KEY")
+response = client.export_submissions_csv("550e8400-e29b-41d4-a716-446655440000")
+with open("submissions.csv", "wb") as f:
+    f.write(response.content)
+```
+
+### `export_submission_pdf(form_id, submission_id)`
+
+**Authenticated.** Export a single submission as a PDF.
+
+```
+GET {base_url}/api/forms/{form_id}/submissions/{submission_id}/submission-pdf
+Authorization: Bearer {api_key}
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `form_id` | `str` | UUID of the form |
+| `submission_id` | `str` | UUID of the submission |
+
+**Returns** `Response` — PDF bytes (`application/pdf`). Use `response.content` for the bytes.
+
+**Raises**
+- `ValueError` — if the client has no `api_key`.
+- `requests.exceptions.HTTPError` — on 404 (form or submission not found) or other HTTP errors.
+
+**Example**
+
+```python
+import paubox
+
+client = paubox.PauboxFormsClient(api_key="YOUR_SCOPED_API_KEY")
+response = client.export_submission_pdf(
+    "550e8400-e29b-41d4-a716-446655440000",
+    "9b2d1c3e-4f5a-6789-abcd-ef0123456789"
+)
+with open("submission.pdf", "wb") as f:
+    f.write(response.content)
+```
+
 ---
 
 ## Error Handling
@@ -241,6 +593,8 @@ try:
 except ValueError as e:
     print(e)  # "form_data is required and must not be empty"
 ```
+
+Authenticated Forms methods likewise raise `ValueError` before any network call if the client was constructed without an `api_key`.
 
 ---
 

--- a/paubox/forms.py
+++ b/paubox/forms.py
@@ -6,6 +6,9 @@ require a Paubox scoped API key with the 'forms' scope (or a JWT), sent as
 a Bearer token.
 """
 
+import uuid
+from urllib.parse import quote
+
 import requests
 from .paubox import Response
 from .helpers.errors import handle_error
@@ -72,6 +75,58 @@ class PauboxFormsClient(object):
             cleaned[key] = value
         return cleaned
 
+    @staticmethod
+    def _path_segment(value, name, require_uuid=True):
+        """
+        Sanitize a caller-supplied value before interpolating it into a URL path.
+
+        Without this, a value containing "..", "/", "?" or "#" changes which
+        endpoint is called. `requests` collapses dot-segments while preparing a
+        URL, so the retargeting happens client-side — no server or proxy
+        involvement is needed. An application that passes user input through to
+        a form or submission id would otherwise be able to reach an endpoint it
+        did not intend to call, and a rewritten path can leave the /forms base
+        path on the same host, taking the Authorization header with it (requests
+        only strips that header across a host change).
+
+        :param value: Caller-supplied path segment — a form or submission UUID.
+        :type value: str
+        :param name: Argument name, used in the error message.
+        :type name: str
+        :param require_uuid: Reject anything that is not a UUID. True for the
+            authenticated endpoints, which are new in 1.2.0 and so have no
+            existing callers to stay compatible with. False for the
+            long-standing public endpoints, where percent-encoding alone closes
+            the issue without rejecting ids that used to be accepted.
+        :type require_uuid: bool
+        :returns: The value, percent-encoded for use as a single path segment.
+        :rtype: str
+        :raises ValueError: if the value is empty, or is not a UUID while
+            require_uuid is True.
+        """
+        if value is None or value == "":
+            raise ValueError(f"{name} is required and must not be empty.")
+        value = str(value)
+        # "." and ".." are dot-segments: they are resolved away rather than sent,
+        # so they always retarget the request. Percent-encoding does not help —
+        # quote() leaves "." alone (it is unreserved), and requests un-escapes
+        # %2E during preparation anyway. Neither is ever a valid id, so reject
+        # them outright rather than depending on requests' internal ordering.
+        if value in (".", ".."):
+            raise ValueError(
+                f"{name} must not be {value!r}, which is not a valid id."
+            )
+        if require_uuid:
+            try:
+                uuid.UUID(value)
+            except (AttributeError, TypeError, ValueError):
+                raise ValueError(
+                    f"{name} must be a UUID, got {value!r}."
+                )
+        # Encoded even after UUID validation, so that this stays safe if the
+        # validation above is ever relaxed.
+        return quote(value, safe="")
+
     def get_form(self, form_id):
         """
         Retrieve a form's metadata, HTML, JSON schema, and CSS by UUID.
@@ -84,8 +139,10 @@ class PauboxFormsClient(object):
         :type form_id: str
         :returns: Response containing the form definition.
         :rtype: Response
+        :raises ValueError: if form_id is empty or a bare dot-segment.
         :raises requests.exceptions.HTTPError: on 404 or other HTTP errors.
         """
+        form_id = self._path_segment(form_id, "form_id", require_uuid=False)
         url = f"{self.base_url}/public/form_data/{form_id}"
         try:
             response = requests.get(url, headers={"Content-Type": "application/json"})
@@ -112,12 +169,14 @@ class PauboxFormsClient(object):
         :type attachments: list or None
         :returns: Response with status 201 and no body on success.
         :rtype: Response
-        :raises ValueError: if form_data is None or empty.
+        :raises ValueError: if form_data is None or empty, or if form_id is
+            empty or a bare dot-segment.
         :raises requests.exceptions.HTTPError: on 400, 404, or other HTTP errors.
         """
         if not form_data:
             raise ValueError("form_data is required and must not be empty")
 
+        form_id = self._path_segment(form_id, "form_id", require_uuid=False)
         url = f"{self.base_url}/api/forms/{form_id}/submissions"
         payload = {"form_data": form_data}
         if attachments:
@@ -197,11 +256,13 @@ class PauboxFormsClient(object):
         :type form_id: str
         :returns: Response with {"data": {...form...}}.
         :rtype: Response
-        :raises ValueError: if the client has no api_key.
+        :raises ValueError: if the client has no api_key, or if form_id
+            is not a UUID.
         :raises requests.exceptions.HTTPError: on 401, 403, 404, or other
             HTTP errors.
         """
         headers = self._auth_headers()
+        form_id = self._path_segment(form_id, "form_id")
         url = f"{self.base_url}/api/forms/{form_id}"
         try:
             response = requests.get(url, headers=headers)
@@ -316,11 +377,13 @@ class PauboxFormsClient(object):
         :returns: Response with {"detail": "Form updated successfully",
             "form_id": "<id>"}.
         :rtype: Response
-        :raises ValueError: if the client has no api_key.
+        :raises ValueError: if the client has no api_key, or if form_id
+            is not a UUID.
         :raises requests.exceptions.HTTPError: on 401, 403, 404 (form not
             found), or other HTTP errors.
         """
         headers = self._auth_headers()
+        form_id = self._path_segment(form_id, "form_id")
         url = f"{self.base_url}/api/forms/{form_id}"
         candidates = {
             "title": title,
@@ -349,10 +412,12 @@ class PauboxFormsClient(object):
         :type form_id: str
         :returns: Response with {"detail": "Form archived."}.
         :rtype: Response
-        :raises ValueError: if the client has no api_key.
+        :raises ValueError: if the client has no api_key, or if form_id
+            is not a UUID.
         :raises requests.exceptions.HTTPError: on 401, 403, or other HTTP errors.
         """
         headers = self._auth_headers()
+        form_id = self._path_segment(form_id, "form_id")
         url = f"{self.base_url}/api/forms/{form_id}/archive"
         try:
             response = requests.post(url, headers=headers)
@@ -371,10 +436,12 @@ class PauboxFormsClient(object):
         :type form_id: str
         :returns: Response with {"detail": "Form unarchived."}.
         :rtype: Response
-        :raises ValueError: if the client has no api_key.
+        :raises ValueError: if the client has no api_key, or if form_id
+            is not a UUID.
         :raises requests.exceptions.HTTPError: on 401, 403, or other HTTP errors.
         """
         headers = self._auth_headers()
+        form_id = self._path_segment(form_id, "form_id")
         url = f"{self.base_url}/api/forms/{form_id}/unarchive"
         try:
             response = requests.post(url, headers=headers)
@@ -461,11 +528,13 @@ class PauboxFormsClient(object):
             string), storage_type, storage_url, submitter_email, recipients,
             attachment_name, attachment_url, attachment_type, and created_at.
         :rtype: Response
-        :raises ValueError: if the client has no api_key.
+        :raises ValueError: if the client has no api_key, or if form_id
+            is not a UUID.
         :raises requests.exceptions.HTTPError: on 401, 403, 404 (form not
             found), or other HTTP errors.
         """
         headers = self._auth_headers()
+        form_id = self._path_segment(form_id, "form_id")
         url = f"{self.base_url}/api/forms/{form_id}/submissions"
         params = self._query_params({
             "submission_id": submission_id,
@@ -497,13 +566,16 @@ class PauboxFormsClient(object):
         :returns: Response whose content property holds the CSV bytes
             (text/csv attachment).
         :rtype: Response
-        :raises ValueError: if the client has no api_key.
+        :raises ValueError: if the client has no api_key, or if form_id
+            or submission_id is not a UUID.
         :raises requests.exceptions.HTTPError: on 401, 403, 404, or other
             HTTP errors.
         """
         headers = self._auth_headers()
+        form_id = self._path_segment(form_id, "form_id")
         url = f"{self.base_url}/api/forms/{form_id}/submissions/submission-csv"
         if submission_id is not None:
+            submission_id = self._path_segment(submission_id, "submission_id")
             url = f"{url}/{submission_id}"
         try:
             response = requests.get(url, headers=headers)
@@ -525,11 +597,14 @@ class PauboxFormsClient(object):
         :returns: Response whose content property holds the PDF bytes
             (application/pdf attachment).
         :rtype: Response
-        :raises ValueError: if the client has no api_key.
+        :raises ValueError: if the client has no api_key, or if form_id
+            or submission_id is not a UUID.
         :raises requests.exceptions.HTTPError: on 401, 403, 404, or other
             HTTP errors.
         """
         headers = self._auth_headers()
+        form_id = self._path_segment(form_id, "form_id")
+        submission_id = self._path_segment(submission_id, "submission_id")
         url = f"{self.base_url}/api/forms/{form_id}/submissions/{submission_id}/submission-pdf"
         try:
             response = requests.get(url, headers=headers)

--- a/paubox/forms.py
+++ b/paubox/forms.py
@@ -1,7 +1,9 @@
 """
 Paubox Forms API client.
-Public endpoints for retrieving form definitions and submitting responses.
-No authentication is required for these endpoints.
+Public endpoints for retrieving form definitions and submitting responses
+require no authentication. Form management and submission-export endpoints
+require a Paubox scoped API key with the 'forms' scope (or a JWT), sent as
+a Bearer token.
 """
 
 import requests
@@ -12,20 +14,71 @@ FORMS_BASE_URL = "https://apx.paubox.com/forms"
 
 
 class PauboxFormsClient(object):
-    """Client for the Paubox Forms API (public endpoints, no authentication required)."""
+    """Client for the Paubox Forms API.
 
-    def __init__(self, base_url=FORMS_BASE_URL):
+    Public endpoints (get_form, submit_form) require no authentication.
+    All other endpoints require an API key with the 'forms' scope.
+    """
+
+    def __init__(self, base_url=FORMS_BASE_URL, api_key=None):
         """
         :param base_url: Forms API base URL. Defaults to https://apx.paubox.com/forms.
         :type base_url: str
+        :param api_key: Optional Paubox scoped API key (or JWT) with the 'forms'
+            scope. Required for the authenticated form management and
+            submission-export endpoints; not used by the public endpoints.
+        :type api_key: str or None
         """
         self.base_url = base_url
+        self.api_key = api_key
+
+    def _auth_headers(self):
+        """
+        Build request headers for authenticated endpoints.
+
+        :returns: Headers dict with Content-Type and Authorization.
+        :rtype: dict
+        :raises ValueError: if the client was constructed without an api_key.
+        """
+        if not self.api_key:
+            raise ValueError(
+                "An API key is required for this endpoint. Pass api_key to "
+                "PauboxFormsClient — the key must be a Paubox scoped API key "
+                "with the 'forms' scope."
+            )
+        return {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+    @staticmethod
+    def _query_params(params):
+        """
+        Build query params: drop None values and serialize booleans as the
+        lowercase strings "true"/"false" (required by the server's query
+        parsing).
+
+        :param params: Candidate query parameters.
+        :type params: dict
+        :returns: Cleaned query parameters.
+        :rtype: dict
+        """
+        cleaned = {}
+        for key, value in params.items():
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                value = "true" if value else "false"
+            cleaned[key] = value
+        return cleaned
 
     def get_form(self, form_id):
         """
         Retrieve a form's metadata, HTML, JSON schema, and CSS by UUID.
 
         GET /public/form_data/{form_id}
+
+        Public endpoint — no authentication required.
 
         :param form_id: UUID of the form to retrieve.
         :type form_id: str
@@ -47,6 +100,7 @@ class PauboxFormsClient(object):
 
         POST /api/forms/{form_id}/submissions
 
+        Public endpoint — no authentication required.
         Maximum request size is 250 MB (to support file attachments).
 
         :param form_id: UUID of the form being submitted.
@@ -73,6 +127,412 @@ class PauboxFormsClient(object):
             response = requests.post(
                 url, json=payload, headers={"Content-Type": "application/json"}
             )
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def list_forms(self, customer_id=None, form_id=None, search=None, order=None,
+                   order_by=None, archived=None, active=None, page=None, items=None):
+        """
+        List forms, with optional filtering, ordering, and pagination.
+
+        GET /api/forms
+
+        :param customer_id: Customer whose forms to list. Effectively required
+            for API-key callers: the server returns 403 Forbidden when it is
+            omitted, so pass the customer ID your key is scoped to (or a
+            related customer's).
+        :type customer_id: int or None
+        :param form_id: Filter to a single form UUID.
+        :type form_id: str or None
+        :param search: Substring match against form title and description.
+        :type search: str or None
+        :param order: Sort direction, "asc" or "desc". Defaults to "desc".
+        :type order: str or None
+        :param order_by: Sort column: "title", "updated_at", or
+            "submission_count". Anything else falls back to "created_at".
+        :type order_by: str or None
+        :param archived: Filter by archived state.
+        :type archived: bool or None
+        :param active: Filter by active state.
+        :type active: bool or None
+        :param page: Page number, starting at 1. Defaults to 1.
+        :type page: int or None
+        :param items: Items per page. Defaults to 50; the server caps it at 100.
+        :type items: int or None
+        :returns: Response with {"results": [form...], "page_info": {"count",
+            "pages", "page", "items"}}.
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, or other HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms"
+        params = self._query_params({
+            "customer_id": customer_id,
+            "form_id": form_id,
+            "search": search,
+            "order": order,
+            "order_by": order_by,
+            "archived": archived,
+            "active": active,
+            "page": page,
+            "items": items,
+        })
+        try:
+            response = requests.get(url, params=params, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def get_form_by_id(self, form_id):
+        """
+        Retrieve a form by UUID (authenticated variant of get_form).
+
+        GET /api/forms/{form_id}
+
+        :param form_id: UUID of the form to retrieve.
+        :type form_id: str
+        :returns: Response with {"data": {...form...}}.
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, 404, or other
+            HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms/{form_id}"
+        try:
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def create_form(self, title, form_json, customer_id, description=None,
+                    form_html=None, form_css=None, recipient=None, signable=False,
+                    signature_confirmation_label=None, subscription_list_id=None,
+                    form_type=None, active=False, version=1, submission_count=0):
+        """
+        Create a new form.
+
+        POST /api/forms
+
+        :param title: Form title.
+        :type title: str
+        :param form_json: Form definition (the form's JSON schema).
+        :type form_json: dict
+        :param customer_id: Customer the form belongs to.
+        :type customer_id: int
+        :param description: Optional form description.
+        :type description: str or None
+        :param form_html: Optional rendered form HTML.
+        :type form_html: str or None
+        :param form_css: Optional form CSS.
+        :type form_css: str or None
+        :param recipient: Comma-separated string of notification email
+            addresses.
+        :type recipient: str or None
+        :param signable: Whether the form is signable. Defaults to False.
+        :type signable: bool
+        :param signature_confirmation_label: Optional signature confirmation
+            label.
+        :type signature_confirmation_label: str or None
+        :param subscription_list_id: Optional connected Marketing contact list.
+        :type subscription_list_id: str or None
+        :param form_type: Optional form type (sent as the JSON key "type"),
+            e.g. "marketing_form".
+        :type form_type: str or None
+        :param active: Whether the form is active. Defaults to False.
+        :type active: bool
+        :param version: Form version. Defaults to 1.
+        :type version: int
+        :param submission_count: Initial submission count. Defaults to 0.
+        :type submission_count: int
+        :returns: Response with {"id": "<new-uuid>"}.
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, or other HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms"
+        payload = {
+            "title": title,
+            "form_json": form_json,
+            "customer_id": customer_id,
+            "signable": signable,
+            "active": active,
+            "version": version,
+            "submission_count": submission_count,
+        }
+        optional = {
+            "description": description,
+            "form_html": form_html,
+            "form_css": form_css,
+            "recipient": recipient,
+            "signature_confirmation_label": signature_confirmation_label,
+            "subscription_list_id": subscription_list_id,
+            "type": form_type,
+        }
+        for key, value in optional.items():
+            if value is not None:
+                payload[key] = value
+        try:
+            response = requests.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def update_form(self, form_id, title=None, description=None, form_json=None,
+                    vanity_url=None, recipient=None, active=None,
+                    subscription_list_id=None):
+        """
+        Update a form. PATCH-style merge: only the arguments that are not None
+        are sent, and only those fields are changed on the server.
+
+        PUT /api/forms/{form_id}
+
+        :param form_id: UUID of the form to update.
+        :type form_id: str
+        :param title: New form title.
+        :type title: str or None
+        :param description: New form description.
+        :type description: str or None
+        :param form_json: New form definition.
+        :type form_json: dict or None
+        :param vanity_url: New vanity URL. Note: the server currently accepts
+            this field but does not persist it — the value is silently ignored
+            even though the call returns 200.
+        :type vanity_url: str or None
+        :param recipient: Comma-separated string of notification email
+            addresses.
+        :type recipient: str or None
+        :param active: New active state.
+        :type active: bool or None
+        :param subscription_list_id: Connected Marketing contact list.
+        :type subscription_list_id: str or None
+        :returns: Response with {"detail": "Form updated successfully",
+            "form_id": "<id>"}.
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, 404 (form not
+            found), or other HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms/{form_id}"
+        candidates = {
+            "title": title,
+            "description": description,
+            "form_json": form_json,
+            "vanity_url": vanity_url,
+            "recipient": recipient,
+            "active": active,
+            "subscription_list_id": subscription_list_id,
+        }
+        payload = {key: value for key, value in candidates.items() if value is not None}
+        try:
+            response = requests.put(url, json=payload, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def archive_form(self, form_id):
+        """
+        Archive a form (archiving also deactivates it server-side).
+
+        POST /api/forms/{form_id}/archive
+
+        :param form_id: UUID of the form to archive.
+        :type form_id: str
+        :returns: Response with {"detail": "Form archived."}.
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, or other HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms/{form_id}/archive"
+        try:
+            response = requests.post(url, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def unarchive_form(self, form_id):
+        """
+        Unarchive a form.
+
+        POST /api/forms/{form_id}/unarchive
+
+        :param form_id: UUID of the form to unarchive.
+        :type form_id: str
+        :returns: Response with {"detail": "Form unarchived."}.
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, or other HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms/{form_id}/unarchive"
+        try:
+            response = requests.post(url, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def copy_form(self, form_id, title):
+        """
+        Copy an existing form under a new title. The copy gets a fresh UUID,
+        a cleared vanity_url, and a submission_count of 0.
+
+        POST /api/forms/copy
+
+        :param form_id: UUID of the form to copy.
+        :type form_id: str
+        :param title: Title for the new copy.
+        :type title: str
+        :returns: Response containing the full new form object.
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, 404 (source form
+            not found), or other HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms/copy"
+        payload = {"form_id": form_id, "title": title}
+        try:
+            response = requests.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def get_form_stats(self, customer_id=None):
+        """
+        Retrieve form statistics for a customer.
+
+        GET /api/forms/stats
+
+        :param customer_id: Customer to get stats for. Defaults server-side to
+            the API key's customer.
+        :type customer_id: int or None
+        :returns: Response with {"active_form_count",
+            "total_submission_count", "submissions_last_7_days"}.
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, or other HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms/stats"
+        params = self._query_params({"customer_id": customer_id})
+        try:
+            response = requests.get(url, params=params, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def list_submissions(self, form_id, submission_id=None, order_by=None,
+                         order=None, page=None, items=None):
+        """
+        List submissions for a form, with optional filtering, ordering, and
+        pagination.
+
+        GET /api/forms/{form_id}/submissions
+
+        :param form_id: UUID of the form.
+        :type form_id: str
+        :param submission_id: Filter to a single submission UUID.
+        :type submission_id: str or None
+        :param order_by: Sort column: "submitter_email". Anything else falls
+            back to "created_at".
+        :type order_by: str or None
+        :param order: Sort direction, "asc" or "desc". Defaults to "desc".
+        :type order: str or None
+        :param page: Page number, starting at 1. Defaults to 1.
+        :type page: int or None
+        :param items: Items per page. Defaults to 50; the server caps it at 100.
+        :type items: int or None
+        :returns: Response with {"data": [submission...], "total", "page",
+            "items"}. Each submission has id, form_id, form_data (a JSON
+            string), storage_type, storage_url, submitter_email, recipients,
+            attachment_name, attachment_url, attachment_type, and created_at.
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, 404 (form not
+            found), or other HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms/{form_id}/submissions"
+        params = self._query_params({
+            "submission_id": submission_id,
+            "order_by": order_by,
+            "order": order,
+            "page": page,
+            "items": items,
+        })
+        try:
+            response = requests.get(url, params=params, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def export_submissions_csv(self, form_id, submission_id=None):
+        """
+        Export a form's submissions as CSV.
+
+        GET /api/forms/{form_id}/submissions/submission-csv (all submissions)
+        GET /api/forms/{form_id}/submissions/submission-csv/{submission_id}
+        (a single submission)
+
+        :param form_id: UUID of the form.
+        :type form_id: str
+        :param submission_id: Optional UUID of a single submission to export.
+            Omit to export all of the form's submissions.
+        :type submission_id: str or None
+        :returns: Response whose content property holds the CSV bytes
+            (text/csv attachment).
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, 404, or other
+            HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms/{form_id}/submissions/submission-csv"
+        if submission_id is not None:
+            url = f"{url}/{submission_id}"
+        try:
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise handle_error(error)
+        return Response(response)
+
+    def export_submission_pdf(self, form_id, submission_id):
+        """
+        Export a single form submission as PDF.
+
+        GET /api/forms/{form_id}/submissions/{submission_id}/submission-pdf
+
+        :param form_id: UUID of the form.
+        :type form_id: str
+        :param submission_id: UUID of the submission to export.
+        :type submission_id: str
+        :returns: Response whose content property holds the PDF bytes
+            (application/pdf attachment).
+        :rtype: Response
+        :raises ValueError: if the client has no api_key.
+        :raises requests.exceptions.HTTPError: on 401, 403, 404, or other
+            HTTP errors.
+        """
+        headers = self._auth_headers()
+        url = f"{self.base_url}/api/forms/{form_id}/submissions/{submission_id}/submission-pdf"
+        try:
+            response = requests.get(url, headers=headers)
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
             raise handle_error(error)

--- a/paubox/paubox.py
+++ b/paubox/paubox.py
@@ -16,6 +16,7 @@ class Response(object):
         self._status_code = response.status_code
         self._headers = response.headers
         self._text = response.text
+        self._content = response.content
 
     @property
     def status_code(self):
@@ -37,6 +38,13 @@ class Response(object):
         :return: Body of Paubox API response
         """
         return self._text
+
+    @property
+    def content(self):
+        """
+        :return: Body of Paubox API response as raw bytes
+        """
+        return self._content
 
     @property
     def to_dict(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="paubox-python3",
-    version="1.1.0",
+    version="1.2.0",
     author="Paubox",
     author_email="info@paubox.com",
     description="Python3 SDK for Paubox Email and Forms REST APIs",

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -768,6 +768,173 @@ class TestResponseContent(TestCase):
         self.assertEqual(response.to_dict, {"a": 1})
 
 
+# Hostile values for anything interpolated into a URL path. Each one changes
+# which endpoint is called if the segment reaches the URL unencoded, because
+# `requests` collapses dot-segments while preparing the URL.
+HOSTILE_SEGMENTS = [
+    "../submission-csv",          # single -> bulk export
+    "..",                         # export -> list endpoint
+    "../../../../../v1/messages",  # escapes /forms entirely, same host
+    "../../../admin/customers",
+    "abc#",                       # splices a fragment, dropping later segments
+    "abc?items=100",              # splices a query, overriding our own params
+    "a/b",
+    "%2e%2e/x",
+]
+
+
+class TestPathSegmentSanitization(TestCase):
+    """
+    A caller-supplied form or submission id must never be able to change which
+    endpoint is called. Assertions are on the URL the client *builds* — a
+    retargeted request can return a perfectly valid 200, so status is not a
+    useful signal here.
+    """
+
+    def _requested_url(self, mock):
+        args, kwargs = mock.call_args
+        return args[0] if args else kwargs["url"]
+
+    def _prepared_path(self, url, params=None):
+        """Resolve the URL the way requests will, including dot-segments."""
+        return requests.Request("GET", url, params=params).prepare().url
+
+    def test_authenticated_methods_reject_non_uuid_form_id(self):
+        client = PauboxFormsClient(api_key=API_KEY)
+        calls = [
+            ("get_form_by_id", lambda c, v: c.get_form_by_id(v)),
+            ("update_form", lambda c, v: c.update_form(v, title="x")),
+            ("archive_form", lambda c, v: c.archive_form(v)),
+            ("unarchive_form", lambda c, v: c.unarchive_form(v)),
+            ("list_submissions", lambda c, v: c.list_submissions(v)),
+            ("export_submissions_csv", lambda c, v: c.export_submissions_csv(v)),
+            ("export_submission_pdf",
+             lambda c, v: c.export_submission_pdf(v, SUBMISSION_ID)),
+        ]
+        for name, call in calls:
+            for hostile in HOSTILE_SEGMENTS:
+                with self.subTest(method=name, value=hostile):
+                    with patch("paubox.forms.requests.get") as mock_get, \
+                            patch("paubox.forms.requests.post") as mock_post, \
+                            patch("paubox.forms.requests.put") as mock_put:
+                        with self.assertRaises(ValueError):
+                            call(client, hostile)
+                        mock_get.assert_not_called()
+                        mock_post.assert_not_called()
+                        mock_put.assert_not_called()
+
+    def test_export_submissions_csv_rejects_traversing_submission_id(self):
+        """The escalation that motivated this: single-row export -> bulk export."""
+        client = PauboxFormsClient(api_key=API_KEY)
+        for hostile in HOSTILE_SEGMENTS:
+            with self.subTest(value=hostile):
+                with patch("paubox.forms.requests.get") as mock_get:
+                    with self.assertRaises(ValueError):
+                        client.export_submissions_csv(
+                            FORM_ID, submission_id=hostile
+                        )
+                    mock_get.assert_not_called()
+
+    def test_export_submission_pdf_rejects_traversing_submission_id(self):
+        client = PauboxFormsClient(api_key=API_KEY)
+        for hostile in HOSTILE_SEGMENTS:
+            with self.subTest(value=hostile):
+                with patch("paubox.forms.requests.get") as mock_get:
+                    with self.assertRaises(ValueError):
+                        client.export_submission_pdf(FORM_ID, hostile)
+                    mock_get.assert_not_called()
+
+    def test_public_endpoints_encode_rather_than_reject(self):
+        """
+        get_form/submit_form predate this change, so they must not start
+        rejecting ids that used to be accepted — but the segment still has to be
+        encoded so it cannot retarget the request. The bare dot-segments are the
+        one exception: they are rejected everywhere (see the test below).
+        """
+        client = PauboxFormsClient()
+        for hostile in [s for s in HOSTILE_SEGMENTS if s not in (".", "..")]:
+            with self.subTest(value=hostile):
+                with patch("paubox.forms.requests.get") as mock_get:
+                    mock_get.return_value = _mock_response(200, "{}")
+                    client.get_form(hostile)
+                    url = self._requested_url(mock_get)
+                prefix = f"{FORMS_BASE_URL}/public/form_data/"
+                self.assertTrue(
+                    url.startswith(prefix),
+                    f"{hostile!r} escaped the endpoint: {url}",
+                )
+                # The invariant that matters: after requests resolves the URL it
+                # must still address this endpoint. Encoded dots may survive
+                # (..%2Fx is inert — it is not a dot-segment); what must not
+                # happen is prepare_url resolving them into a different path.
+                self.assertTrue(
+                    self._prepared_path(url).startswith(prefix),
+                    f"{hostile!r} retargeted the request: "
+                    f"{self._prepared_path(url)}",
+                )
+
+    def test_dot_segments_are_rejected_on_public_endpoints_too(self):
+        """
+        "." and ".." cannot be neutralized by encoding — quote() leaves "."
+        alone, and requests un-escapes %2E during preparation. Neither is a
+        valid id, so both are rejected even where we otherwise stay permissive.
+        """
+        client = PauboxFormsClient()
+        for bad in [".", ".."]:
+            with self.subTest(value=bad):
+                with patch("paubox.forms.requests.get") as mock_get, \
+                        patch("paubox.forms.requests.post") as mock_post:
+                    with self.assertRaises(ValueError):
+                        client.get_form(bad)
+                    with self.assertRaises(ValueError):
+                        client.submit_form(bad, {"a": "b"})
+                    mock_get.assert_not_called()
+                    mock_post.assert_not_called()
+
+    def test_empty_and_none_ids_are_rejected_before_any_request(self):
+        client = PauboxFormsClient(api_key=API_KEY)
+        for bad in ["", None]:
+            with self.subTest(value=bad):
+                with patch("paubox.forms.requests.get") as mock_get:
+                    with self.assertRaises(ValueError):
+                        client.get_form_by_id(bad)
+                    with self.assertRaises(ValueError):
+                        client.export_submission_pdf(FORM_ID, bad)
+                    mock_get.assert_not_called()
+
+    def test_valid_uuids_still_build_the_documented_urls(self):
+        """The hardening must not change the happy path."""
+        client = PauboxFormsClient(api_key=API_KEY)
+        with patch("paubox.forms.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(200, "{}")
+            client.export_submission_pdf(FORM_ID, SUBMISSION_ID)
+            self.assertEqual(
+                self._requested_url(mock_get),
+                f"{FORMS_BASE_URL}/api/forms/{FORM_ID}/submissions/"
+                f"{SUBMISSION_ID}/submission-pdf",
+            )
+        with patch("paubox.forms.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(200, "{}")
+            client.export_submissions_csv(FORM_ID, submission_id=SUBMISSION_ID)
+            self.assertEqual(
+                self._requested_url(mock_get),
+                f"{FORMS_BASE_URL}/api/forms/{FORM_ID}/submissions/"
+                f"submission-csv/{SUBMISSION_ID}",
+            )
+
+    def test_uppercase_uuid_is_accepted_unchanged(self):
+        """UUIDs are hex; case must not be treated as hostile."""
+        client = PauboxFormsClient(api_key=API_KEY)
+        upper = FORM_ID.upper()
+        with patch("paubox.forms.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(200, "{}")
+            client.get_form_by_id(upper)
+            self.assertEqual(
+                self._requested_url(mock_get),
+                f"{FORMS_BASE_URL}/api/forms/{upper}",
+            )
+
+
 if __name__ == "__main__":
     SUITE = unittest.TestLoader().loadTestsFromModule(__import__(__name__))
     unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -13,13 +13,20 @@ from paubox.forms import PauboxFormsClient, FORMS_BASE_URL
 TestCase.maxDiff = None
 
 FORM_ID = "550e8400-e29b-41d4-a716-446655440000"
+SUBMISSION_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+API_KEY = "0123456789abcdef0123456789abcdef"
+AUTH_HEADERS = {
+    "Content-Type": "application/json",
+    "Authorization": f"Bearer {API_KEY}",
+}
 
 
-def _mock_response(status_code=200, text="", raise_for_status=None):
+def _mock_response(status_code=200, text="", raise_for_status=None, content=b""):
     mock = MagicMock()
     mock.status_code = status_code
     mock.headers = {"Content-Type": "application/json"}
     mock.text = text
+    mock.content = content
     if raise_for_status:
         mock.raise_for_status.side_effect = raise_for_status
     else:
@@ -46,6 +53,24 @@ class TestPauboxFormsClientInit(TestCase):
     def test_custom_base_url(self):
         client = PauboxFormsClient(base_url="http://localhost:3000")
         self.assertEqual(client.base_url, "http://localhost:3000")
+
+    def test_api_key_defaults_to_none(self):
+        client = PauboxFormsClient()
+        self.assertIsNone(client.api_key)
+
+    def test_api_key_stored(self):
+        client = PauboxFormsClient(api_key=API_KEY)
+        self.assertEqual(client.api_key, API_KEY)
+
+    def test_base_url_still_first_positional(self):
+        client = PauboxFormsClient("http://localhost:3000")
+        self.assertEqual(client.base_url, "http://localhost:3000")
+        self.assertIsNone(client.api_key)
+
+    def test_base_url_and_api_key_positional(self):
+        client = PauboxFormsClient("http://localhost:3000", API_KEY)
+        self.assertEqual(client.base_url, "http://localhost:3000")
+        self.assertEqual(client.api_key, API_KEY)
 
 
 class TestGetForm(TestCase):
@@ -187,6 +212,560 @@ class TestSubmitForm(TestCase):
         client = PauboxFormsClient()
         with self.assertRaises(requests.exceptions.HTTPError):
             client.submit_form(FORM_ID, form_data={"x": "y"})
+
+
+class TestAuthRequired(TestCase):
+    """Every authenticated method raises ValueError without an api_key
+    and makes no HTTP call."""
+
+    def _assert_requires_api_key(self, call):
+        client = PauboxFormsClient()
+        with patch("paubox.forms.requests.get") as mock_get, \
+                patch("paubox.forms.requests.post") as mock_post, \
+                patch("paubox.forms.requests.put") as mock_put:
+            with self.assertRaises(ValueError):
+                call(client)
+            mock_get.assert_not_called()
+            mock_post.assert_not_called()
+            mock_put.assert_not_called()
+
+    def test_list_forms_requires_api_key(self):
+        self._assert_requires_api_key(lambda c: c.list_forms())
+
+    def test_get_form_by_id_requires_api_key(self):
+        self._assert_requires_api_key(lambda c: c.get_form_by_id(FORM_ID))
+
+    def test_create_form_requires_api_key(self):
+        self._assert_requires_api_key(
+            lambda c: c.create_form("Title", {"fields": []}, 1234)
+        )
+
+    def test_update_form_requires_api_key(self):
+        self._assert_requires_api_key(lambda c: c.update_form(FORM_ID, title="x"))
+
+    def test_archive_form_requires_api_key(self):
+        self._assert_requires_api_key(lambda c: c.archive_form(FORM_ID))
+
+    def test_unarchive_form_requires_api_key(self):
+        self._assert_requires_api_key(lambda c: c.unarchive_form(FORM_ID))
+
+    def test_copy_form_requires_api_key(self):
+        self._assert_requires_api_key(lambda c: c.copy_form(FORM_ID, "Copy"))
+
+    def test_get_form_stats_requires_api_key(self):
+        self._assert_requires_api_key(lambda c: c.get_form_stats())
+
+    def test_list_submissions_requires_api_key(self):
+        self._assert_requires_api_key(lambda c: c.list_submissions(FORM_ID))
+
+    def test_export_submissions_csv_requires_api_key(self):
+        self._assert_requires_api_key(lambda c: c.export_submissions_csv(FORM_ID))
+
+    def test_export_submission_pdf_requires_api_key(self):
+        self._assert_requires_api_key(
+            lambda c: c.export_submission_pdf(FORM_ID, SUBMISSION_ID)
+        )
+
+
+class TestListForms(TestCase):
+    """Tests for PauboxFormsClient.list_forms."""
+
+    @patch("paubox.forms.requests.get")
+    def test_list_forms_calls_correct_url_with_auth(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.list_forms()
+        mock_get.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms",
+            params={},
+            headers=AUTH_HEADERS,
+        )
+
+    @patch("paubox.forms.requests.get")
+    def test_list_forms_omits_none_params(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.list_forms(search="intake", page=2)
+        _, kwargs = mock_get.call_args
+        self.assertEqual(kwargs["params"], {"search": "intake", "page": 2})
+
+    @patch("paubox.forms.requests.get")
+    def test_list_forms_serializes_booleans_lowercase(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.list_forms(archived=True, active=False)
+        _, kwargs = mock_get.call_args
+        self.assertEqual(kwargs["params"], {"archived": "true", "active": "false"})
+
+    @patch("paubox.forms.requests.get")
+    def test_list_forms_passes_all_params(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.list_forms(
+            customer_id=1234,
+            form_id=FORM_ID,
+            search="intake",
+            order="asc",
+            order_by="title",
+            archived=False,
+            active=True,
+            page=3,
+            items=25,
+        )
+        _, kwargs = mock_get.call_args
+        self.assertEqual(
+            kwargs["params"],
+            {
+                "customer_id": 1234,
+                "form_id": FORM_ID,
+                "search": "intake",
+                "order": "asc",
+                "order_by": "title",
+                "archived": "false",
+                "active": "true",
+                "page": 3,
+                "items": 25,
+            },
+        )
+
+    @patch("paubox.forms.requests.get")
+    def test_list_forms_parses_response(self, mock_get):
+        body = (
+            '{"results": [{"id": "550e8400-e29b-41d4-a716-446655440000"}],'
+            '"page_info": {"count": 1, "pages": 1, "page": 1, "items": 50}}'
+        )
+        mock_get.return_value = _mock_response(status_code=200, text=body)
+        client = PauboxFormsClient(api_key=API_KEY)
+        response = client.list_forms()
+        data = response.to_dict
+        self.assertEqual(data["results"][0]["id"], FORM_ID)
+        self.assertEqual(data["page_info"]["count"], 1)
+
+    @patch("paubox.forms.requests.get")
+    def test_list_forms_forbidden_raises_http_error(self, mock_get):
+        mock_get.return_value = _mock_response(
+            status_code=403, raise_for_status=_http_error(403)
+        )
+        client = PauboxFormsClient(api_key=API_KEY)
+        with self.assertRaises(requests.exceptions.HTTPError):
+            client.list_forms()
+
+
+class TestGetFormById(TestCase):
+    """Tests for PauboxFormsClient.get_form_by_id."""
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_by_id_calls_correct_url_with_auth(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.get_form_by_id(FORM_ID)
+        mock_get.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms/{FORM_ID}",
+            headers=AUTH_HEADERS,
+        )
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_by_id_parses_response(self, mock_get):
+        body = f'{{"data": {{"id": "{FORM_ID}", "title": "Patient Intake Form"}}}}'
+        mock_get.return_value = _mock_response(status_code=200, text=body)
+        client = PauboxFormsClient(api_key=API_KEY)
+        response = client.get_form_by_id(FORM_ID)
+        self.assertEqual(response.to_dict["data"]["id"], FORM_ID)
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_by_id_not_found_raises_http_error(self, mock_get):
+        mock_get.return_value = _mock_response(
+            status_code=404, raise_for_status=_http_error(404)
+        )
+        client = PauboxFormsClient(api_key=API_KEY)
+        with self.assertRaises(requests.exceptions.HTTPError):
+            client.get_form_by_id(FORM_ID)
+
+
+class TestCreateForm(TestCase):
+    """Tests for PauboxFormsClient.create_form."""
+
+    @patch("paubox.forms.requests.post")
+    def test_create_form_calls_correct_url_with_auth(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=200, text='{"id": "x"}')
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.create_form("Intake", {"fields": []}, 1234)
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], f"{FORMS_BASE_URL}/api/forms")
+        self.assertEqual(kwargs["headers"], AUTH_HEADERS)
+
+    @patch("paubox.forms.requests.post")
+    def test_create_form_required_fields_and_defaults(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=200, text='{"id": "x"}')
+        client = PauboxFormsClient(api_key=API_KEY)
+        form_json = {"fields": [{"name": "first_name"}]}
+        client.create_form("Intake", form_json, 1234)
+        _, kwargs = mock_post.call_args
+        self.assertEqual(
+            kwargs["json"],
+            {
+                "title": "Intake",
+                "form_json": form_json,
+                "customer_id": 1234,
+                "signable": False,
+                "active": False,
+                "version": 1,
+                "submission_count": 0,
+            },
+        )
+
+    @patch("paubox.forms.requests.post")
+    def test_create_form_omits_none_optionals(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=200, text='{"id": "x"}')
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.create_form("Intake", {"fields": []}, 1234)
+        _, kwargs = mock_post.call_args
+        for key in (
+            "description",
+            "form_html",
+            "form_css",
+            "recipient",
+            "signature_confirmation_label",
+            "subscription_list_id",
+            "type",
+        ):
+            self.assertNotIn(key, kwargs["json"])
+
+    @patch("paubox.forms.requests.post")
+    def test_create_form_form_type_maps_to_type_key(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=200, text='{"id": "x"}')
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.create_form("Intake", {"fields": []}, 1234, form_type="marketing_form")
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs["json"]["type"], "marketing_form")
+        self.assertNotIn("form_type", kwargs["json"])
+
+    @patch("paubox.forms.requests.post")
+    def test_create_form_includes_optionals_when_set(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=200, text='{"id": "x"}')
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.create_form(
+            "Intake",
+            {"fields": []},
+            1234,
+            description="Patient intake",
+            recipient="a@example.com,b@example.com",
+            signable=True,
+            active=True,
+        )
+        _, kwargs = mock_post.call_args
+        payload = kwargs["json"]
+        self.assertEqual(payload["description"], "Patient intake")
+        self.assertEqual(payload["recipient"], "a@example.com,b@example.com")
+        self.assertTrue(payload["signable"])
+        self.assertTrue(payload["active"])
+
+    @patch("paubox.forms.requests.post")
+    def test_create_form_parses_response(self, mock_post):
+        mock_post.return_value = _mock_response(
+            status_code=200, text=f'{{"id": "{FORM_ID}"}}'
+        )
+        client = PauboxFormsClient(api_key=API_KEY)
+        response = client.create_form("Intake", {"fields": []}, 1234)
+        self.assertEqual(response.to_dict["id"], FORM_ID)
+
+
+class TestUpdateForm(TestCase):
+    """Tests for PauboxFormsClient.update_form."""
+
+    @patch("paubox.forms.requests.put")
+    def test_update_form_calls_correct_url_with_auth(self, mock_put):
+        mock_put.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.update_form(FORM_ID, title="New Title")
+        args, kwargs = mock_put.call_args
+        self.assertEqual(args[0], f"{FORMS_BASE_URL}/api/forms/{FORM_ID}")
+        self.assertEqual(kwargs["headers"], AUTH_HEADERS)
+
+    @patch("paubox.forms.requests.put")
+    def test_update_form_sends_only_non_none_keys(self, mock_put):
+        mock_put.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.update_form(FORM_ID, title="New Title")
+        _, kwargs = mock_put.call_args
+        self.assertEqual(kwargs["json"], {"title": "New Title"})
+
+    @patch("paubox.forms.requests.put")
+    def test_update_form_with_no_fields_sends_empty_body(self, mock_put):
+        mock_put.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.update_form(FORM_ID)
+        _, kwargs = mock_put.call_args
+        self.assertEqual(kwargs["json"], {})
+
+    @patch("paubox.forms.requests.put")
+    def test_update_form_active_false_is_sent(self, mock_put):
+        mock_put.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.update_form(FORM_ID, active=False)
+        _, kwargs = mock_put.call_args
+        self.assertEqual(kwargs["json"], {"active": False})
+
+    @patch("paubox.forms.requests.put")
+    def test_update_form_not_found_raises_http_error(self, mock_put):
+        mock_put.return_value = _mock_response(
+            status_code=404, raise_for_status=_http_error(404)
+        )
+        client = PauboxFormsClient(api_key=API_KEY)
+        with self.assertRaises(requests.exceptions.HTTPError):
+            client.update_form(FORM_ID, title="x")
+
+
+class TestArchiveUnarchiveForm(TestCase):
+    """Tests for PauboxFormsClient.archive_form and unarchive_form."""
+
+    @patch("paubox.forms.requests.post")
+    def test_archive_form_calls_correct_url_with_auth_and_empty_body(self, mock_post):
+        mock_post.return_value = _mock_response(
+            status_code=200, text='{"detail": "Form archived."}'
+        )
+        client = PauboxFormsClient(api_key=API_KEY)
+        response = client.archive_form(FORM_ID)
+        mock_post.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms/{FORM_ID}/archive",
+            headers=AUTH_HEADERS,
+        )
+        self.assertEqual(response.to_dict["detail"], "Form archived.")
+
+    @patch("paubox.forms.requests.post")
+    def test_unarchive_form_calls_correct_url_with_auth_and_empty_body(self, mock_post):
+        mock_post.return_value = _mock_response(
+            status_code=200, text='{"detail": "Form unarchived."}'
+        )
+        client = PauboxFormsClient(api_key=API_KEY)
+        response = client.unarchive_form(FORM_ID)
+        mock_post.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms/{FORM_ID}/unarchive",
+            headers=AUTH_HEADERS,
+        )
+        self.assertEqual(response.to_dict["detail"], "Form unarchived.")
+
+
+class TestCopyForm(TestCase):
+    """Tests for PauboxFormsClient.copy_form."""
+
+    @patch("paubox.forms.requests.post")
+    def test_copy_form_calls_correct_url_with_auth_and_payload(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.copy_form(FORM_ID, "Intake (Copy)")
+        mock_post.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms/copy",
+            json={"form_id": FORM_ID, "title": "Intake (Copy)"},
+            headers=AUTH_HEADERS,
+        )
+
+    @patch("paubox.forms.requests.post")
+    def test_copy_form_not_found_raises_http_error(self, mock_post):
+        mock_post.return_value = _mock_response(
+            status_code=404, raise_for_status=_http_error(404)
+        )
+        client = PauboxFormsClient(api_key=API_KEY)
+        with self.assertRaises(requests.exceptions.HTTPError):
+            client.copy_form(FORM_ID, "Copy")
+
+
+class TestGetFormStats(TestCase):
+    """Tests for PauboxFormsClient.get_form_stats."""
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_stats_without_customer_id(self, mock_get):
+        body = (
+            '{"active_form_count": 3, "total_submission_count": 120,'
+            '"submissions_last_7_days": 7}'
+        )
+        mock_get.return_value = _mock_response(status_code=200, text=body)
+        client = PauboxFormsClient(api_key=API_KEY)
+        response = client.get_form_stats()
+        mock_get.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms/stats",
+            params={},
+            headers=AUTH_HEADERS,
+        )
+        self.assertEqual(response.to_dict["active_form_count"], 3)
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_stats_with_customer_id(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.get_form_stats(customer_id=1234)
+        mock_get.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms/stats",
+            params={"customer_id": 1234},
+            headers=AUTH_HEADERS,
+        )
+
+
+class TestListSubmissions(TestCase):
+    """Tests for PauboxFormsClient.list_submissions."""
+
+    @patch("paubox.forms.requests.get")
+    def test_list_submissions_calls_correct_url_with_auth(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.list_submissions(FORM_ID)
+        mock_get.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms/{FORM_ID}/submissions",
+            params={},
+            headers=AUTH_HEADERS,
+        )
+
+    @patch("paubox.forms.requests.get")
+    def test_list_submissions_passes_params(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.list_submissions(
+            FORM_ID,
+            submission_id=SUBMISSION_ID,
+            order_by="submitter_email",
+            order="asc",
+            page=2,
+            items=10,
+        )
+        _, kwargs = mock_get.call_args
+        self.assertEqual(
+            kwargs["params"],
+            {
+                "submission_id": SUBMISSION_ID,
+                "order_by": "submitter_email",
+                "order": "asc",
+                "page": 2,
+                "items": 10,
+            },
+        )
+
+    @patch("paubox.forms.requests.get")
+    def test_list_submissions_parses_response(self, mock_get):
+        body = (
+            f'{{"data": [{{"id": "{SUBMISSION_ID}", "form_id": "{FORM_ID}",'
+            '"form_data": "{\\"first_name\\": \\"Jane\\"}",'
+            '"submitter_email": "jane@example.com"}],'
+            '"total": 1, "page": 1, "items": 50}'
+        )
+        mock_get.return_value = _mock_response(status_code=200, text=body)
+        client = PauboxFormsClient(api_key=API_KEY)
+        response = client.list_submissions(FORM_ID)
+        data = response.to_dict
+        self.assertEqual(data["total"], 1)
+        self.assertEqual(data["data"][0]["id"], SUBMISSION_ID)
+        self.assertIsInstance(data["data"][0]["form_data"], str)
+
+    @patch("paubox.forms.requests.get")
+    def test_list_submissions_not_found_raises_http_error(self, mock_get):
+        mock_get.return_value = _mock_response(
+            status_code=404, raise_for_status=_http_error(404)
+        )
+        client = PauboxFormsClient(api_key=API_KEY)
+        with self.assertRaises(requests.exceptions.HTTPError):
+            client.list_submissions(FORM_ID)
+
+
+class TestExportSubmissionsCsv(TestCase):
+    """Tests for PauboxFormsClient.export_submissions_csv."""
+
+    @patch("paubox.forms.requests.get")
+    def test_export_all_submissions_url(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, content=b"a,b\n1,2\n")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.export_submissions_csv(FORM_ID)
+        mock_get.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms/{FORM_ID}/submissions/submission-csv",
+            headers=AUTH_HEADERS,
+        )
+
+    @patch("paubox.forms.requests.get")
+    def test_export_single_submission_url(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, content=b"a,b\n1,2\n")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.export_submissions_csv(FORM_ID, submission_id=SUBMISSION_ID)
+        mock_get.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms/{FORM_ID}/submissions/submission-csv/{SUBMISSION_ID}",
+            headers=AUTH_HEADERS,
+        )
+
+    @patch("paubox.forms.requests.get")
+    def test_export_csv_content_returns_bytes(self, mock_get):
+        csv_bytes = b"first_name,last_name\nJane,Doe\n"
+        mock_get.return_value = _mock_response(status_code=200, content=csv_bytes)
+        client = PauboxFormsClient(api_key=API_KEY)
+        response = client.export_submissions_csv(FORM_ID)
+        self.assertEqual(response.content, csv_bytes)
+
+
+class TestExportSubmissionPdf(TestCase):
+    """Tests for PauboxFormsClient.export_submission_pdf."""
+
+    @patch("paubox.forms.requests.get")
+    def test_export_pdf_calls_correct_url_with_auth(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, content=b"%PDF-1.4")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.export_submission_pdf(FORM_ID, SUBMISSION_ID)
+        mock_get.assert_called_once_with(
+            f"{FORMS_BASE_URL}/api/forms/{FORM_ID}/submissions/{SUBMISSION_ID}/submission-pdf",
+            headers=AUTH_HEADERS,
+        )
+
+    @patch("paubox.forms.requests.get")
+    def test_export_pdf_content_returns_bytes(self, mock_get):
+        pdf_bytes = b"%PDF-1.4 fake pdf body"
+        mock_get.return_value = _mock_response(status_code=200, content=pdf_bytes)
+        client = PauboxFormsClient(api_key=API_KEY)
+        response = client.export_submission_pdf(FORM_ID, SUBMISSION_ID)
+        self.assertEqual(response.content, pdf_bytes)
+
+    @patch("paubox.forms.requests.get")
+    def test_export_pdf_not_found_raises_http_error(self, mock_get):
+        mock_get.return_value = _mock_response(
+            status_code=404, raise_for_status=_http_error(404)
+        )
+        client = PauboxFormsClient(api_key=API_KEY)
+        with self.assertRaises(requests.exceptions.HTTPError):
+            client.export_submission_pdf(FORM_ID, SUBMISSION_ID)
+
+
+class TestPublicEndpointsWithApiKey(TestCase):
+    """Public endpoints must not send an Authorization header even when the
+    client has an api_key."""
+
+    @patch("paubox.forms.requests.get")
+    def test_get_form_sends_no_auth_header_with_api_key(self, mock_get):
+        mock_get.return_value = _mock_response(status_code=200, text="{}")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.get_form(FORM_ID)
+        _, kwargs = mock_get.call_args
+        self.assertNotIn("Authorization", kwargs.get("headers", {}))
+
+    @patch("paubox.forms.requests.post")
+    def test_submit_form_sends_no_auth_header_with_api_key(self, mock_post):
+        mock_post.return_value = _mock_response(status_code=201, text="")
+        client = PauboxFormsClient(api_key=API_KEY)
+        client.submit_form(FORM_ID, form_data={"x": "y"})
+        _, kwargs = mock_post.call_args
+        self.assertNotIn("Authorization", kwargs.get("headers", {}))
+
+
+class TestResponseContent(TestCase):
+    """Tests for the Response.content property."""
+
+    def test_response_content_returns_raw_bytes(self):
+        from paubox.paubox import Response
+        raw = b"\x89PNG\r\n\x1a\n binary payload"
+        response = Response(_mock_response(status_code=200, content=raw))
+        self.assertEqual(response.content, raw)
+
+    def test_response_content_and_text_coexist(self):
+        from paubox.paubox import Response
+        response = Response(
+            _mock_response(status_code=200, text='{"a": 1}', content=b'{"a": 1}')
+        )
+        self.assertEqual(response.text, '{"a": 1}')
+        self.assertEqual(response.content, b'{"a": 1}')
+        self.assertEqual(response.to_dict, {"a": 1})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extends `PauboxFormsClient` with the full authenticated Paubox Forms API surface exposed by the Forms server (pb_rforms). Authentication uses a **Paubox scoped API key carrying the `forms` scope** (or a JWT), sent as `Authorization: Bearer <token>` — matching the server's auth middleware, which validates dot-less tokens as scoped API keys against IAM.

## New client methods

**Form management**
- `list_forms(customer_id, form_id, search, order, order_by, archived, active, page, items)` — paginated listing with search/filter/sort
- `get_form_by_id(form_id)` — authenticated form retrieval (distinct from the public `get_form`)
- `create_form(title, form_json, customer_id, ...)`
- `update_form(form_id, ...)` — PATCH-style: only the arguments you pass are sent, since the server overwrites any key present in the body
- `archive_form(form_id)` / `unarchive_form(form_id)`
- `copy_form(form_id, title)`
- `get_form_stats(customer_id=None)`

**Submissions**
- `list_submissions(form_id, submission_id, order_by, order, page, items)`
- `export_submissions_csv(form_id, submission_id=None)` — all submissions or a single one
- `export_submission_pdf(form_id, submission_id)`

## Design notes

- New optional `api_key` constructor argument; `base_url` stays the first positional, so existing `PauboxFormsClient(base_url)` callers are unaffected.
- Authenticated methods raise `ValueError` before any network call when no key is configured.
- The public endpoints (`get_form`, `submit_form`) are unchanged and still send no auth header, even when an `api_key` is set.
- Boolean query params are serialized as lowercase `"true"`/`"false"` — the server's serde query parsing rejects Python's default `True`/`False` capitalization.
- `form_type` maps to the JSON key `"type"` on create.
- `Response` gains a `content` property (raw bytes) for the binary CSV/PDF exports; `text`/`to_dict` are unchanged.
- `list_forms` documents `customer_id` as effectively required for API-key callers: the server returns 403 when it is omitted (API keys never carry `super_admin`, and the relationship check only runs when the param is present).
- `update_form`'s `vanity_url` is documented as a current server-side no-op (merged in the handler but missing from the SQL UPDATE — worth an upstream fix in pb_rforms).

## Testing

- 55 new mock-based unit tests (72 total, all passing; no credentials needed): `PYTHONPATH=. python tests/test_forms.py`
- Every endpoint path, query param, payload key, and response shape was cross-checked against the Rust server source, plus an adversarial review pass comparing the SDK and docs to the server implementation.

## Docs

README (new authenticated-endpoints section with examples), full api.md reference for all 11 methods, CHANGELOG entry, CLAUDE.md corrections, version bump 1.1.0 → 1.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6U9rW8YgVSkejZPbvNU5y

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6U9rW8YgVSkejZPbvNU5y)_